### PR TITLE
HLOD bake without LODGroup

### DIFF
--- a/com.unity.hlod/Editor/Splitter/SplitterBase.cs
+++ b/com.unity.hlod/Editor/Splitter/SplitterBase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using Unity.HLODSystem.Utils;
 using UnityEditor;
 using UnityEditor.Experimental.SceneManagement;
 using UnityEditor.SceneManagement;
@@ -23,7 +25,7 @@ namespace Unity.HLODSystem
             if (hlod == null)
                 return;
 
-            var childGroups = hlod.GetComponentsInChildren<LODGroup>();
+            var childTargets = FindObjects.HLODTargets(hlod.gameObject);
             var data = GetData(hlod);
 
             for (int c = 0; c < data.Length; ++c)
@@ -31,16 +33,16 @@ namespace Unity.HLODSystem
                 data[c].GameObject.transform.SetParent(hlod.transform);
             }
 
-            for (int i = 0; i < childGroups.Length; ++i)
+            for (int i = 0; i < childTargets.Count; ++i)
             {
                 for (int c = 0; c < data.Length; ++c)
                 {
-                    if (data[c].Bounds.Contains(childGroups[i].transform.position) == false)
+                    if (data[c].Bounds.Contains(childTargets[i].transform.position) == false)
                     {
                         continue;
                     }
 
-                    ChildMove(childGroups[i].gameObject, hlod.gameObject, data[c].GameObject);
+                    ChildMove(childTargets[i], hlod.gameObject, data[c].GameObject);
                 }
             }
 

--- a/com.unity.hlod/Editor/Utils.meta
+++ b/com.unity.hlod/Editor/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34a36dca32f044648879ca639fbd35d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.hlod/Editor/Utils/FindObjects.cs
+++ b/com.unity.hlod/Editor/Utils/FindObjects.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Unity.HLODSystem.Utils
+{
+    public static class FindObjects
+    {
+        //It must order by child first.
+        //Because we need to make child prefab first.
+        public static T[] GetComponentsInChildren<T>(GameObject root) where T : Component
+        {
+            LinkedList<T> result = new LinkedList<T>();
+            Queue<GameObject> queue = new Queue<GameObject>();
+            queue.Enqueue(root);
+
+            while (queue.Count > 0)
+            {
+                GameObject go = queue.Dequeue();
+                T component = go.GetComponent<T>();
+                if (component != null)
+                    result.AddFirst(component);
+
+                foreach (Transform child in go.transform)
+                {
+                    queue.Enqueue(child.gameObject);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        public static List<GameObject> HLODTargets(GameObject root)
+        {
+            List<GameObject> targets = new List<GameObject>();
+
+            LODGroup[] lodGroups = GetComponentsInChildren<LODGroup>(root);
+            //This contains all of the mesh renderers, so we need to remove the duplicated mesh renderer which in the LODGroup.
+            List<MeshRenderer> meshRenderers = GetComponentsInChildren<MeshRenderer>(root).ToList();
+
+            //Remove low meshes.
+            meshRenderers.RemoveAll(r => r.GetComponent<LowMeshHolder>() != null);
+            
+
+            for (int i = 0; i < lodGroups.Length; ++i)
+            {
+                LOD[] lods = lodGroups[i].GetLODs();
+                targets.Add(lodGroups[i].gameObject);
+
+                for (int li = 0; li < lods.Length; ++li)
+                {
+                    meshRenderers.RemoveAll(r => lods[li].renderers.Contains(r));
+                }
+            }
+
+            //Combine renderer which in the LODGroup and renderer which without the LODGroup.
+            targets.AddRange(meshRenderers.Select(r => r.gameObject));
+
+            return targets;
+        }
+    }
+
+}

--- a/com.unity.hlod/Editor/Utils/FindObjects.cs.meta
+++ b/com.unity.hlod/Editor/Utils/FindObjects.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 456f456a9c15a164cb0bb5f84c631bde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.hlod/Runtime/Utils/LowMeshHolder.cs
+++ b/com.unity.hlod/Runtime/Utils/LowMeshHolder.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Unity.HLODSystem.Utils
+{
+    public class LowMeshHolder : MonoBehaviour
+    {
+    }
+
+}

--- a/com.unity.hlod/Runtime/Utils/LowMeshHolder.cs.meta
+++ b/com.unity.hlod/Runtime/Utils/LowMeshHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bff51859525ba9942b87087ff1675a52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Create HLOD Mesh without LODGroup.
If we use the mesh included in FBX directly, we can't be able to use HLOD because the editor can not create LODGroup.