### PR TITLE
Fixed error when build empty node with the SimpleBatcher.

### DIFF
--- a/com.unity.hlod/Editor/TexturePacker.cs
+++ b/com.unity.hlod/Editor/TexturePacker.cs
@@ -222,6 +222,11 @@ namespace Unity.HLODSystem
 
             public TextureAtlas CreateAtlas(TextureFormat format, int packTextureSize, bool linear)
             {
+                if (m_textures.Count == 0)
+                {
+                    return null;
+                }
+                
                 int itemCount = Mathf.CeilToInt(Mathf.Sqrt(m_textures.Count));
                 int itemSize = packTextureSize / itemCount;
                 TextureAtlas atlas;
@@ -358,7 +363,8 @@ namespace Unity.HLODSystem
                 for (int i = 0; i < m_sources.Count; ++i)
                 {
                     TextureAtlas item = m_sources[i].CreateAtlas(m_format, m_packTextureSize, m_linear);
-                    atlases.Add(item);
+                    if ( item != null )
+                        atlases.Add(item);
                 }
                 return atlases;
 


### PR DESCRIPTION
### Purpose of this PR
A _device by zero error_ occurs when the m_texture count in the TexturePacker is zero.
If the count of the texture is 0, it returns null without creating it and removes it from the process.

---
### Release Notes
Fixed file name problem in the HLOD FeatureSamples.

---
### Testing status
I've checked an empty node fine with the SimpleBatcher.
---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**:  Low

---
### Comments to reviewers
