### PR TITLE
Show dialog when there is no object to be included in the HLOD.

### DIFF
--- a/com.unity.hlod/Editor/HLODCreator.cs
+++ b/com.unity.hlod/Editor/HLODCreator.cs
@@ -145,6 +145,19 @@ namespace Unity.HLODSystem
 
                 using (DisposableList<HLODBuildInfo> buildInfos = CreateBuildInfo(rootNode, hlod.MinObjectSize))
                 {
+                    if (buildInfos.Count == 0)
+                        yield break;
+
+                    if (buildInfos[0].WorkingObjects.Count == 0)
+                    {
+                        if (EditorUtility.DisplayDialog("Empty HLOD sources.",
+                                "There are no objects to be included in the HLOD.\nDo you want to continue anyway?",
+                                "Continue", "Cancel") == false)
+                        {
+                            yield break;
+                        }
+                    }
+                    
                     Debug.Log("[HLOD] Splite space: " + sw.Elapsed.ToString("g"));
                     sw.Reset();
                     sw.Start();


### PR DESCRIPTION
### Purpose of this PR
Show dialog when there is no object to be included in the HLOD.
I give the user the choice to continue.
The HLODSystem has to still work even there is no object to be included.

---
### Release Notes
Show dialog when there is no object to be included in the HLOD.
---

### Testing status
I've checked the dialog shows well.
clicked continue, it works, clicked cancel, it stopped.
Some case does not work but it is another problem.
---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers

