### PR TITLE
Fixed to the controller does not work with an empty node in Addressable

### DIFF
--- a/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
+++ b/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
@@ -199,9 +199,13 @@ namespace Unity.HLODSystem.Streaming
                 }
 
                 {
-                    string filename = $"{filenamePrefix}_group{infos[i].ParentIndex}.hlod";
-                    int lowId = addressableController.AddLowObject(filename + "." + infos[i].Name);
-                    hlodTreeNode.LowObjectIds.Add(lowId);
+                    if (rootDatas[infos[i].ParentIndex].GetRootObject(infos[i].Name) != null)
+                    {
+                        string filename = $"{filenamePrefix}_group{infos[i].ParentIndex}.hlod";
+                        int lowId = addressableController.AddLowObject(filename + "." + infos[i].Name);
+                        hlodTreeNode.LowObjectIds.Add(lowId);    
+                    }
+
                 }
             }
             


### PR DESCRIPTION
### Purpose of this PR
an error occurs because the node is not found by requesting the node. So, avoid requiring a node if it is not created.

---
### Release Notes
Fixed to the controller does not work with an empty node in Addressable

---
### Testing status
I've checked that the error no longer occurs after fix.

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: Low

---
### Comments to reviewers
