### PR TITLE
Changed default min object size to zero.

### DIFF
--- a/com.unity.hlod/Runtime/HLOD.cs
+++ b/com.unity.hlod/Runtime/HLOD.cs
@@ -20,7 +20,7 @@ namespace Unity.HLODSystem
         [SerializeField]
         private float m_CullDistance = 0.01f;
         [SerializeField]
-        private float m_MinObjectSize = 5.0f;
+        private float m_MinObjectSize = 0.0f;
 
         private Type m_BatcherType;
         


### PR DESCRIPTION
### Purpose of this PR
Changed default min object size to zero.

---
### Release Notes
Changed default min object size to zero.

---
### Testing status


---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None,

---
### Comments to reviewers
