### PR TITLE
Fixed to find materials created as a Sub-Asset.

### DIFF
--- a/com.unity.hlod/Editor/HLODData.cs
+++ b/com.unity.hlod/Editor/HLODData.cs
@@ -244,6 +244,18 @@ namespace Unity.HLODSystem
                 else
                 {
                     string path = AssetDatabase.GUIDToAssetPath(m_assetGuid);
+                    var objects = AssetDatabase.LoadAllAssetsAtPath(path);
+                    for (int i = 0; i < objects.Length; ++i)
+                    {
+                        Material mat = objects[i] as Material;
+                        
+                        if (mat == null)
+                            continue;
+
+                        if (mat.name == m_name)
+                            return mat;
+                    }
+                    
                     return AssetDatabase.LoadAssetAtPath<Material>(path);
                 }
             }

--- a/com.unity.hlod/Editor/Utils/WorkingMaterial.cs
+++ b/com.unity.hlod/Editor/Utils/WorkingMaterial.cs
@@ -63,8 +63,12 @@ namespace Unity.HLODSystem.Utils
         }
         public  WorkingMaterial(Allocator allocator, int materialId, bool copy) : this(allocator)
         {
+            Material mat = EditorUtility.InstanceIDToObject(materialId) as Material;
+
+            Name = mat.name;
             m_instanceID = materialId;
             m_copy = copy;
+            m_guid = System.Guid.NewGuid().ToString("N");
         }
 
         public bool NeedWrite()


### PR DESCRIPTION
### Purpose of this PR
The AssetDatabase returning the first matching type asset when using the LoadAsset method. If there is more than an object which is the same type, it was used the first found object only. 
I've changed to use the object with the same name in the same type.

---
### Release Notes
Fixed to find materials created as a Sub-Asset.

---
### Testing status
Make sure the MaterialPreservingBatcher supports Sub-asset materials.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Medium. It needs to re-build HLOD which baked before.

---
### Comments to reviewers
