### PR TITLE
Fixed not to call InstanceIDToObject in BackgroundThread.

### DIFF
--- a/com.unity.hlod/Editor/Batcher/MaterialPreservingBatcher.cs
+++ b/com.unity.hlod/Editor/Batcher/MaterialPreservingBatcher.cs
@@ -44,6 +44,7 @@ namespace Unity.HLODSystem
         {
             var instancesTable = new Dictionary<Material, List<CombineInstance>>();
             var combineInfos = new Dictionary<int, List<MeshCombiner.CombineInfo>>();
+            var materialNames = new Dictionary<int, string>();
 
             for (int i = 0; i < info.WorkingObjects.Count; ++i)
             {
@@ -63,6 +64,7 @@ namespace Unity.HLODSystem
                     if (combineInfos.ContainsKey(materials[m].InstanceID) == false)
                     {
                         combineInfos.Add(materials[m].InstanceID, new List<MeshCombiner.CombineInfo>());
+                        materialNames.Add(materials[m].InstanceID, materials[m].Name);
                     }
                     
                     combineInfos[materials[m].InstanceID].Add(combineInfo);
@@ -75,7 +77,7 @@ namespace Unity.HLODSystem
             {
                 WorkingMesh combinedMesh = combiner.CombineMesh(Allocator.Persistent, pair.Value);
                 WorkingObject combinedObject = new WorkingObject(Allocator.Persistent);
-                WorkingMaterial material = new WorkingMaterial(Allocator.Persistent, pair.Key, false);
+                WorkingMaterial material = new WorkingMaterial(Allocator.Persistent, pair.Key, materialNames[pair.Key], false);
 
                 combinedMesh.name = info.Name + "_Mesh" + pair.Key;
                 combinedObject.Name = info.Name;

--- a/com.unity.hlod/Editor/Batcher/SimpleBatcher.cs
+++ b/com.unity.hlod/Editor/Batcher/SimpleBatcher.cs
@@ -156,7 +156,7 @@ namespace Unity.HLODSystem
                 Material mat = AssetDatabase.LoadAssetAtPath<Material>(path);
                 if (mat != null)
                 {
-                    material = new WorkingMaterial(Allocator.Invalid, mat.GetInstanceID(), true);
+                    material = new WorkingMaterial(Allocator.Invalid, mat.GetInstanceID(), mat.name, true);
                 }
             }
 

--- a/com.unity.hlod/Editor/TerrainHLODCreator.cs
+++ b/com.unity.hlod/Editor/TerrainHLODCreator.cs
@@ -173,6 +173,7 @@ namespace Unity.HLODSystem
 
         private Material m_terrainMaterial;
         private int m_terrainMaterialInstanceId;
+        private string m_terrainMaterialName;
 
         
         private TerrainHLODCreator(TerrainHLOD hlod)
@@ -290,7 +291,7 @@ namespace Unity.HLODSystem
 
         private WorkingMaterial CreateBakedMaterial(string name, Bounds bounds)
         {
-            WorkingMaterial material = new WorkingMaterial(Allocator.Persistent, m_terrainMaterialInstanceId, true);
+            WorkingMaterial material = new WorkingMaterial(Allocator.Persistent, m_terrainMaterialInstanceId, m_terrainMaterialName, true);
             material.Name = name + "_Material";
 
             m_queue.EnqueueJob(() =>
@@ -856,6 +857,7 @@ namespace Unity.HLODSystem
                     m_terrainMaterial = new Material(Shader.Find("Standard"));
 
                 m_terrainMaterialInstanceId = m_terrainMaterial.GetInstanceID();
+                m_terrainMaterialName = m_terrainMaterial.name;
 
                 using (m_alphamaps = new DisposableList<WorkingTexture>()) 
                 using ( m_layers = new DisposableList<Layer>())

--- a/com.unity.hlod/Editor/Utils/WorkingMaterial.cs
+++ b/com.unity.hlod/Editor/Utils/WorkingMaterial.cs
@@ -61,11 +61,9 @@ namespace Unity.HLODSystem.Utils
                 m_textures.Add(names[i], texture.ToWorkingTexture(m_allocator));
             }
         }
-        public  WorkingMaterial(Allocator allocator, int materialId, bool copy) : this(allocator)
+        public  WorkingMaterial(Allocator allocator, int materialId, string name,  bool copy) : this(allocator)
         {
-            Material mat = EditorUtility.InstanceIDToObject(materialId) as Material;
-
-            Name = mat.name;
+            Name = name;
             m_instanceID = materialId;
             m_copy = copy;
             m_guid = System.Guid.NewGuid().ToString("N");


### PR DESCRIPTION
### Purpose of this PR
TerrainHLOD works with Multi-Thread, but InstanceIDToObject cannot be called on a background thread. So I modified it to pass the name directly.

---
### Release Notes
Fixed error when generating TerrainHLOD.

---
### Testing status
TerrainHLOD creation and behavior check.

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: None

---
### Comments to reviewers