### PR TITLE
Fixed creating wrong address when using Sub-Asset

### DIFF
--- a/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
+++ b/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
@@ -399,7 +399,7 @@ namespace Unity.HLODSystem.Streaming
                     Object prefab = PrefabUtility.GetCorrespondingObjectFromSource(obj);
                     if (AssetDatabase.IsMainAsset(prefab) == false)
                     {
-                        address = address + "." + prefab.name;
+                        address = address + "[" + prefab.name + "]";
                     }
                 }
 


### PR DESCRIPTION
### Purpose of this PR
After updating Addressable to 1.3.3, Prefab using Sub-Asset will not load.
LowId works fine, but HighId is missing that processing.

---
### Release Notes
Fixed creating wrong address when using Sub-Asset.

---
### Testing status
I've checked that the generated address is correct.
Make sure to load as Addressable when using Sub-Asset.

---
### Overall Product Risks
**Technical Risk**: None
**Halo Effect**: None

---
### Comments to reviewers
