### PR TITLE
Handle error when the output directory does not exist.

### DIFF
--- a/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
+++ b/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
@@ -87,6 +87,12 @@ namespace Unity.HLODSystem.Streaming
 
 
             string filenamePrefix = $"{path}{root.name}";
+            
+            if (Directory.Exists(path) == false)
+            {
+                Directory.CreateDirectory(path);
+            }
+            
             Dictionary<int, HLODData> hlodDatas = new Dictionary<int, HLODData>();
 
             for (int i = 0; i < infos.Count; ++i)

--- a/com.unity.hlod/Editor/Streaming/Unsupported.cs
+++ b/com.unity.hlod/Editor/Streaming/Unsupported.cs
@@ -83,6 +83,11 @@ namespace Unity.HLODSystem.Streaming
             compressionData.tvOSTextureFormat = options.tvOSCompression;
             
             string filename = $"{path}{root.name}.hlod";
+
+            if (Directory.Exists(path) == false)
+            {
+                Directory.CreateDirectory(path);
+            }
             
             using (Stream stream = new FileStream(filename, FileMode.Create))
             {


### PR DESCRIPTION
### Purpose of this PR
An error should not occur when there is no output directory.

---
### Release Notes
Handle error when the output directory does not exist.

---
### Testing status
If there is no output directory, create a folder and create files.

---
### Overall Product Risks
**Technical Risk**: None
**Halo Effect**: None

---
### Comments to reviewers

