### PR TITLE
Initialize variables when enter play mode.

### DIFF
--- a/com.unity.hlod.addressable/Runtime/AddressableLoadManager.cs
+++ b/com.unity.hlod.addressable/Runtime/AddressableLoadManager.cs
@@ -1,11 +1,13 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Unity.HLODSystem.Streaming;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
-using Object = UnityEngine.Object;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace Unity.HLODSystem
 {
@@ -87,6 +89,15 @@ namespace Unity.HLODSystem
         #region Singleton
         private static AddressableLoadManager s_instance;
         private static bool s_isDestroyed = false;
+        
+        #if UNITY_EDITOR
+        [InitializeOnEnterPlayMode]
+        private static void OnEnterPlayMode()
+        {
+            s_instance = null;
+            s_isDestroyed = false;
+        }
+        #endif
         public static AddressableLoadManager Instance
         {
             get


### PR DESCRIPTION
### Purpose of this PR
After 2019.3, static variables may not be initialized when entering play mode. It needs to do manually.

---
### Release Notes
Fixed to error when entering play mode.

---
### Testing status
Make sure no error occurs when entering play mode.

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: None

---
### Comments to reviewers
