### PR TITLE
Devs/addressables bundle management

### DIFF
--- a/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
+++ b/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
@@ -6,6 +6,7 @@ using Unity.HLODSystem.Utils;
 using UnityEditor;
 using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Settings;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -501,8 +502,19 @@ namespace Unity.HLODSystem.Streaming
                 if (settings.groups[i].Name == groupName)
                     return settings.groups[i];
             }
+            
+            List<AddressableAssetGroupSchema> schemas = new List<AddressableAssetGroupSchema>();
 
-            return settings.CreateGroup(groupName, false, false, false, settings.DefaultGroup.Schemas);
+            ContentUpdateGroupSchema contentUpdateGroupSchema = ScriptableObject.CreateInstance<ContentUpdateGroupSchema>();
+            BundledAssetGroupSchema bundledAssetGroupSchema = ScriptableObject.CreateInstance<BundledAssetGroupSchema>();
+
+            bundledAssetGroupSchema.BundleMode = BundledAssetGroupSchema.BundlePackingMode.PackSeparately;
+            
+            schemas.Add(contentUpdateGroupSchema);
+            schemas.Add(bundledAssetGroupSchema);
+
+            AddressableAssetGroup group = settings.CreateGroup(groupName, false, false, false, schemas);
+            return group;
         }
     }
 


### PR DESCRIPTION
### Purpose of this PR
In order to share shaders between bundles, they must be separated. 
Find the shader to be used when creating the HLOD and add it to Addressables. Then, create a bundle to contain the HLOD so that it is separated as a default option.

---
### Release Notes
Add shaders used by HLOD to Addressables.
Specify the AddressableAssetGroup to which the HLOD will be added.

---
### Testing status
Check manually whether the shader is added to the addressable.

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: Low

---
### Comments to reviewers

