### PR TITLE
Fixed an issue where colors were different due to color space mismatch.

### DIFF
--- a/com.unity.hlod/Editor/TerrainHLODCreator.cs
+++ b/com.unity.hlod/Editor/TerrainHLODCreator.cs
@@ -88,6 +88,15 @@ namespace Unity.HLODSystem
                 m_size = layer.tileSize;
                 var diffuseRemapMin = layer.diffuseRemapMin;
                 var diffuseRemapMax = layer.diffuseRemapMax;
+                
+                diffuseRemapMin.x = Mathf.Pow(diffuseRemapMin.x, 0.45f);
+                diffuseRemapMin.y = Mathf.Pow(diffuseRemapMin.y, 0.45f);
+                diffuseRemapMin.z = Mathf.Pow(diffuseRemapMin.z, 0.45f);
+                
+                diffuseRemapMax.x = Mathf.Pow(diffuseRemapMax.x, 0.45f);
+                diffuseRemapMax.y = Mathf.Pow(diffuseRemapMax.y, 0.45f);
+                diffuseRemapMax.z = Mathf.Pow(diffuseRemapMax.z, 0.45f);
+        
 
                 RemapTexture(texture, diffuseRemapMin, diffuseRemapMax);
                 
@@ -385,6 +394,7 @@ namespace Unity.HLODSystem
                             color.r += Mathf.Pow(c.r, 2.2f) * weight;
                             color.g += Mathf.Pow(c.g, 2.2f) * weight;
                             color.b += Mathf.Pow(c.b, 2.2f) * weight;
+                            
                         }
 
                         color.r = Mathf.Pow(color.r, 0.45f);


### PR DESCRIPTION
### Purpose of this PR
BakedTerrain and Terrain have different colors because the color space does not match.

---
### Release Notes
Fixed an issue where colors were different due to color space mismatch.

---
### Testing status
The colors of Terrain and BakedTerrain are not very different.

---
### Overall Product Risks
**Technical Risk**: None,
**Halo Effect**: None, 
---
### Comments to reviewers
Notes for the reviewers you have assigned.
