### PR TITLE
If there is no GUID, a new GUID is created.

### DIFF
--- a/com.unity.hlod/Editor/Utils/WorkingMaterial.cs
+++ b/com.unity.hlod/Editor/Utils/WorkingMaterial.cs
@@ -200,6 +200,10 @@ namespace Unity.HLODSystem.Utils
             m_colors = new Dictionary<string, Color>();
             string path = AssetDatabase.GetAssetPath(mat.GetInstanceID());
             m_guid = AssetDatabase.AssetPathToGUID(path);
+            if (string.IsNullOrEmpty(m_guid))
+            {
+                m_guid = System.Guid.NewGuid().ToString("N");
+            }
                 
             string[] names = mat.GetTexturePropertyNames();
             for (int i = 0; i < names.Length; ++i)


### PR DESCRIPTION
### Purpose of this PR
If there is no material guid because material didn't copied, it fails because it can't find the material.

---
### Release Notes
Fixed TerrainHLOD Bake failure.

---
### Testing status
TerrainHLOD bake succeeded.
---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: Low
---
### Comments to reviewers
Notes for the reviewers you have assigned.
