### PR TITLE
Bugs/#93 exclude disabled mesh

### DIFF
--- a/com.unity.hlod/Editor/Batcher/MaterialPreservingBatcher.cs
+++ b/com.unity.hlod/Editor/Batcher/MaterialPreservingBatcher.cs
@@ -59,6 +59,9 @@ namespace Unity.HLODSystem
                     combineInfo.Mesh = info.WorkingObjects[i].Mesh;
                     combineInfo.MeshIndex = m;
 
+                    if (combineInfo.Mesh == null)
+                        continue;
+
                     if (combineInfos.ContainsKey(materials[m].Identifier) == false)
                     {
                         combineInfos.Add(materials[m].Identifier, new List<MeshCombiner.CombineInfo>());

--- a/com.unity.hlod/Editor/Batcher/SimpleBatcher.cs
+++ b/com.unity.hlod/Editor/Batcher/SimpleBatcher.cs
@@ -298,6 +298,9 @@ namespace Unity.HLODSystem
                     ci.Transform.m03 -= rootPosition.x;
                     ci.Transform.m13 -= rootPosition.y;
                     ci.Transform.m23 -= rootPosition.z;
+
+                    if (ci.Mesh == null)
+                        continue;
                     
                     combineInfos.Add(ci);
                 }

--- a/com.unity.hlod/Editor/HLODCreator.cs
+++ b/com.unity.hlod/Editor/HLODCreator.cs
@@ -25,12 +25,19 @@ namespace Unity.HLODSystem
             for (int oi = 0; oi < gameObjects.Count; ++oi)
             {
                 GameObject obj = gameObjects[oi];
+
+                if (obj.activeInHierarchy == false)
+                    continue;
+                
                 LODGroup[] lodGroups = obj.GetComponentsInChildren<LODGroup>();
                 List<MeshRenderer> allRenderers = obj.GetComponentsInChildren<MeshRenderer>().ToList();
 
                 for (int li = 0; li < lodGroups.Length; ++li)
                 {
                     LODGroup lodGroup = lodGroups[li];
+                    if (lodGroup.enabled == false)
+                        continue;
+                    
                     Renderer[] renderers = lodGroup.GetLODs().Last().renderers;
                     
                     for (int ri = 0; ri < renderers.Length; ++ri)
@@ -38,6 +45,9 @@ namespace Unity.HLODSystem
                         MeshRenderer mr = renderers[ri] as MeshRenderer;
 
                         if (mr == null)
+                            continue;
+                        
+                        if (mr.gameObject.activeInHierarchy == false || mr.enabled == false)
                             continue;
 
                         allRenderers.Remove(mr);
@@ -49,8 +59,12 @@ namespace Unity.HLODSystem
                         meshRenderers.Add(mr);
                     }
                 }
-                
-                meshRenderers.AddRange(allRenderers);
+
+                for (int ai = 0; ai < allRenderers.Count; ++ai)
+                {
+                    if ( allRenderers[ai].enabled == true)
+                        meshRenderers.Add(allRenderers[ai]);
+                }
 
             }
 

--- a/com.unity.hlod/Editor/HLODCreator.cs
+++ b/com.unity.hlod/Editor/HLODCreator.cs
@@ -32,14 +32,28 @@ namespace Unity.HLODSystem
                 LODGroup[] lodGroups = obj.GetComponentsInChildren<LODGroup>();
                 List<MeshRenderer> allRenderers = obj.GetComponentsInChildren<MeshRenderer>().ToList();
 
-                for (int li = 0; li < lodGroups.Length; ++li)
+                for (int gi = 0; gi < lodGroups.Length; ++gi)
                 {
-                    LODGroup lodGroup = lodGroups[li];
-                    if (lodGroup.enabled == false)
+                    LODGroup lodGroup = lodGroups[gi];
+                    if (lodGroup.enabled == false || lodGroup.gameObject.activeInHierarchy == false)
                         continue;
                     
-                    Renderer[] renderers = lodGroup.GetLODs().Last().renderers;
-                    
+                    //all renderers using in LODGroup should be removed in the allRenderers
+                    LOD[] lods = lodGroup.GetLODs();
+                    for (int li = 0; li < lods.Length; ++li)
+                    {
+                        Renderer[] lodRenderers = lods[li].renderers;
+                        for (int ri = 0; ri < lodRenderers.Length; ++ri)
+                        {
+                            MeshRenderer mr = lodRenderers[ri] as MeshRenderer;
+                            if (mr == null)
+                                continue;
+                            
+                            allRenderers.Remove(mr);
+                        }
+                    }
+
+                    Renderer[] renderers = lods.Last().renderers;
                     for (int ri = 0; ri < renderers.Length; ++ri)
                     {
                         MeshRenderer mr = renderers[ri] as MeshRenderer;
@@ -49,8 +63,6 @@ namespace Unity.HLODSystem
                         
                         if (mr.gameObject.activeInHierarchy == false || mr.enabled == false)
                             continue;
-
-                        allRenderers.Remove(mr);
 
                         float max = Mathf.Max(mr.bounds.size.x, mr.bounds.size.y, mr.bounds.size.z);
                         if (max < minObjectSize)
@@ -62,8 +74,10 @@ namespace Unity.HLODSystem
 
                 for (int ai = 0; ai < allRenderers.Count; ++ai)
                 {
-                    if ( allRenderers[ai].enabled == true)
-                        meshRenderers.Add(allRenderers[ai]);
+                    if ( allRenderers[ai].enabled == false || allRenderers[ai].gameObject.activeInHierarchy == false )
+                        continue;
+                    
+                    meshRenderers.Add(allRenderers[ai]);
                 }
 
             }

--- a/com.unity.hlod/Editor/Utils/ObjectUtils.cs
+++ b/com.unity.hlod/Editor/Utils/ObjectUtils.cs
@@ -43,7 +43,11 @@ namespace Unity.HLODSystem.Utils
             
             for (int i = 0; i < lodGroups.Count; ++i)
             {
-                LOD[] lods = lodGroups[i].GetLODs();
+                if ( lodGroups[i].enabled == false )
+                    continue;
+                if (lodGroups[i].gameObject.activeInHierarchy == false)
+                    continue;
+
                 targets.Add(lodGroups[i].gameObject);
 
                 var childMeshRenderers = lodGroups[i].GetComponentsInChildren<MeshRenderer>();
@@ -54,9 +58,16 @@ namespace Unity.HLODSystem.Utils
             }
 
             //Combine renderer which in the LODGroup and renderer which without the LODGroup.
-            targets.AddRange(meshRenderers.Select(r => r.gameObject));
+            for (int ri = 0; ri < meshRenderers.Count; ++ri)
+            {
+                if (meshRenderers[ri].enabled == false)
+                    continue;
 
+                if (meshRenderers[ri].gameObject.activeInHierarchy == false)
+                    continue;
 
+                targets.Add(meshRenderers[ri].gameObject);
+            }
             
             //Combine several LODGroups and MeshRenderers belonging to Prefab into one.
             //Since the minimum unit of streaming is Prefab, it must be set to the minimum unit.


### PR DESCRIPTION
### Purpose of this PR

It was included in the HLOD mesh when the mesh renderer is disabled. It should not be included when disabled.
![image](https://user-images.githubusercontent.com/39615342/169960641-75bb0300-15f6-4892-9bb5-8eeda9cbd531.png)

The following picture is after fix.
![image](https://user-images.githubusercontent.com/39615342/169960662-74cf26bb-ba21-402e-a619-9133c0c25ec2.png)

---
### Release Notes
Exclude mesh when mesh renderer is disabled.

---
### Testing status
Manual

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers

