### PR TITLE
Convert to local when calculating Bounds.

### DIFF
--- a/com.unity.hlod/Editor/HLODCreator.cs
+++ b/com.unity.hlod/Editor/HLODCreator.cs
@@ -192,7 +192,7 @@ namespace Unity.HLODSystem
                 float looseSize = Mathf.Min(hlod.ChunkSize * 0.3f, 5.0f); //< If the chunk size is small, there is a problem that it may get caught in an infinite loop.
                                                                           //So, the size can be determined according to the chunk size.
                 ISpaceSplitter spliter = new QuadTreeSpaceSplitter(looseSize);
-                SpaceNode rootNode = spliter.CreateSpaceTree(bounds, hlod.ChunkSize, hlod.transform.position, hlodTargets, progress =>
+                SpaceNode rootNode = spliter.CreateSpaceTree(bounds, hlod.ChunkSize, hlod.transform, hlodTargets, progress =>
                 {
                     EditorUtility.DisplayProgressBar("Bake HLOD", "Splitting space", progress * 0.25f);
                 });

--- a/com.unity.hlod/Editor/SpaceManager/ISpaceSplitter.cs
+++ b/com.unity.hlod/Editor/SpaceManager/ISpaceSplitter.cs
@@ -10,7 +10,7 @@ namespace Unity.HLODSystem.SpaceManager
         /**
          * @return created root space tree
          */
-        SpaceNode CreateSpaceTree(Bounds initBounds, float chunkSize, Vector3 rootPosition, List<GameObject> targetObjects, Action<float> onProgress);
+        SpaceNode CreateSpaceTree(Bounds initBounds, float chunkSize, Transform transform, List<GameObject> targetObjects, Action<float> onProgress);
     }
 
 }

--- a/com.unity.hlod/Editor/SpaceManager/QuadTreeSpaceSplitter.cs
+++ b/com.unity.hlod/Editor/SpaceManager/QuadTreeSpaceSplitter.cs
@@ -38,7 +38,7 @@ namespace Unity.HLODSystem.SpaceManager
 
             return depth;
         }
-        public SpaceNode CreateSpaceTree(Bounds initBounds, float chunkSize, Vector3 rootPosition, List<GameObject> targetObjects, Action<float> onProgress)
+        public SpaceNode CreateSpaceTree(Bounds initBounds, float chunkSize, Transform transform, List<GameObject> targetObjects, Action<float> onProgress)
         {
             SpaceNode rootNode = new SpaceNode();
             rootNode.Bounds = initBounds;
@@ -71,7 +71,7 @@ namespace Unity.HLODSystem.SpaceManager
 
             for (int oi = 0; oi < targetObjects.Count; ++oi)
             {
-                Bounds? objectBounds = CalculateBounds(targetObjects[oi], rootPosition);
+                Bounds? objectBounds = CalculateBounds(targetObjects[oi], transform);
                 if (objectBounds == null)
                     continue;
 
@@ -120,24 +120,16 @@ namespace Unity.HLODSystem.SpaceManager
             return rootNode;
         }
 
-
-        private Bounds CalcBounds(Renderer renderer, Vector3 rootPosition)
-        {
-            Bounds bounds = renderer.bounds;
-            bounds.center -= rootPosition;
-
-            return bounds;
-        }
-        private Bounds? CalculateBounds(GameObject obj, Vector3 rootPosition)
+        private Bounds? CalculateBounds(GameObject obj, Transform transform)
         {
             MeshRenderer[] renderers = obj.GetComponentsInChildren<MeshRenderer>();
             if (renderers.Length == 0)
                 return null;
 
-            Bounds result = CalcBounds(renderers[0], rootPosition);
+            Bounds result = Utils.BoundsUtils.CalcLocalBounds(renderers[0], transform);
             for (int i = 1; i < renderers.Length; ++i)
             {
-                result.Encapsulate(CalcBounds(renderers[i], rootPosition));
+                result.Encapsulate(Utils.BoundsUtils.CalcLocalBounds(renderers[i], transform));
             }
 
             return result;

--- a/com.unity.hlod/Editor/TerrainHLODCreator.cs
+++ b/com.unity.hlod/Editor/TerrainHLODCreator.cs
@@ -1099,7 +1099,7 @@ namespace Unity.HLODSystem
                             new QuadTreeSpaceSplitter(0.0f);
 
                         SpaceNode rootNode = splitter.CreateSpaceTree(m_hlod.GetBounds(), m_hlod.ChunkSize * 2.0f,
-                        m_hlod.transform.position, null, progress => { });
+                        m_hlod.transform, null, progress => { });
 
                         EditorUtility.DisplayProgressBar("Bake HLOD", "Create mesh", 0.0f);
 

--- a/com.unity.hlod/Runtime/HLOD.cs
+++ b/com.unity.hlod/Runtime/HLOD.cs
@@ -125,14 +125,6 @@ namespace Unity.HLODSystem
             get { return m_convertedPrefabObjects; }
         }
 #endif
-
-        Bounds CalcLocalBounds(Renderer renderer)
-        {
-            Bounds bounds = renderer.bounds;
-            bounds.center -= transform.position;
-
-            return bounds;
-        }
         public Bounds GetBounds()
         {
             Bounds ret = new Bounds();
@@ -144,10 +136,10 @@ namespace Unity.HLODSystem
                 return ret;
             }
 
-            Bounds bounds = CalcLocalBounds(renderers[0]);
+            Bounds bounds = Utils.BoundsUtils.CalcLocalBounds(renderers[0], transform);
             for (int i = 1; i < renderers.Length; ++i)
             {
-                bounds.Encapsulate(CalcLocalBounds(renderers[i]));
+                bounds.Encapsulate(Utils.BoundsUtils.CalcLocalBounds(renderers[i], transform));
             }
 
             ret.center = bounds.center;

--- a/com.unity.hlod/Runtime/HLODTreeNode.cs
+++ b/com.unity.hlod/Runtime/HLODTreeNode.cs
@@ -471,14 +471,14 @@ namespace Unity.HLODSystem
 
 
 
-        public void RenderBounds()
+        public void RenderBounds(Transform transform)
         {
             if (m_fsm.CurrentState == State.Release)
                 return;
 
             for ( int i = 0; i < m_childTreeNodeIds.Count; ++i )
             {
-                m_container.Get(m_childTreeNodeIds[i]).RenderBounds();
+                m_container.Get(m_childTreeNodeIds[i]).RenderBounds(transform);
             }
 
             //if this node has a child node, skipping render.
@@ -505,6 +505,11 @@ namespace Unity.HLODSystem
             vertices[5] = new Vector3(min.x, max.y, max.z);
             vertices[6] = new Vector3(max.x, max.y, max.z);
             vertices[7] = new Vector3(max.x, max.y, min.z);
+
+            for (int i = 0; i < vertices.Length; ++i)
+            {
+                vertices[i] = transform.localToWorldMatrix.MultiplyPoint(vertices[i]);
+            }
 
             CreateLineMaterial();
             // Apply the line material

--- a/com.unity.hlod/Runtime/Streaming/HLODControllerBase.cs
+++ b/com.unity.hlod/Runtime/Streaming/HLODControllerBase.cs
@@ -71,7 +71,7 @@ namespace Unity.HLODSystem.Streaming
             if (m_runtimeDebug == false)
                 return;
 
-            m_root.RenderBounds();
+            m_root.RenderBounds(transform);
         }
         #endregion
 

--- a/com.unity.hlod/Runtime/Utils/BoundsUtils.cs
+++ b/com.unity.hlod/Runtime/Utils/BoundsUtils.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+
+namespace Unity.HLODSystem.Utils
+{
+    public class BoundsUtils
+    {
+        public static Bounds CalcLocalBounds(Renderer renderer, Transform transform)
+        {
+            Bounds bounds = renderer.bounds;
+            Vector3 min = bounds.min;
+            Vector3 max = bounds.max;
+            Matrix4x4 matrix = transform.worldToLocalMatrix;
+
+            Vector3[] points = new[]
+            {
+                new Vector3(min.x, min.y, min.z),
+                new Vector3(max.x, min.y, min.z),
+                new Vector3(min.x, min.y, max.z),
+                new Vector3(max.x, min.y, max.z),
+                new Vector3(min.x, max.y, min.z),
+                new Vector3(max.x, max.y, min.z),
+                new Vector3(min.x, max.y, max.z),
+                new Vector3(max.x, max.y, max.z),
+            };
+
+            for (int i = 0; i < points.Length; ++i)
+            {
+                points[i] = matrix.MultiplyPoint(points[i]);
+            }
+
+            Vector3 newMin = points[0];
+            Vector3 newMax = points[0];
+
+            for (int i = 1; i < points.Length; ++i)
+            {
+                if (newMin.x > points[i].x) newMin.x = points[i].x;
+                if (newMax.x < points[i].x) newMax.x = points[i].x;
+                
+                if (newMin.y > points[i].y) newMin.y = points[i].y;
+                if (newMax.y < points[i].y) newMax.y = points[i].y;
+                
+                if (newMin.z > points[i].z) newMin.z = points[i].z;
+                if (newMax.z < points[i].z) newMax.z = points[i].z;
+            }
+
+
+            Bounds newBounds = new Bounds();
+            newBounds.SetMinMax(newMin, newMax);
+            return newBounds;
+        }
+    }
+}

--- a/com.unity.hlod/Runtime/Utils/BoundsUtils.cs.meta
+++ b/com.unity.hlod/Runtime/Utils/BoundsUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 11a4a7d7cdcb45f0bcd4f9f187639e4b
+timeCreated: 1658997244


### PR DESCRIPTION
### Purpose of this PR
When calculating Bounds, it must be calculated after converting to Local coordinates. 
Transformation logic was wrong, which sometimes results in incorrect calculations if the parent has a transform.

---
### Release Notes
Convert to local when calculating Bounds.

---
### Testing status
Manual

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: High - It doesn't support backwards compatibility.

---
### Comments to reviewers
