### PR TITLE
Fixed to HLOD component is created correctly when it is at the root of the Prefab.

### DIFF
--- a/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
+++ b/com.unity.hlod.addressable/Editor/Streaming/AddressableStreaming.cs
@@ -564,7 +564,7 @@ namespace Unity.HLODSystem.Streaming
                 string address = entry.address;
                 if (string.IsNullOrEmpty(AssetDatabase.GetAssetPath(obj)))
                 {
-                    Object prefab = PrefabUtility.GetCorrespondingObjectFromSource(obj);
+                    Object prefab = PrefabUtility.GetCorrespondingObjectFromOriginalSource(obj);
                     if (AssetDatabase.IsMainAsset(prefab) == false)
                     {
                         address = address + "[" + prefab.name + "]";
@@ -584,7 +584,7 @@ namespace Unity.HLODSystem.Streaming
 
             if (string.IsNullOrEmpty(path) && PrefabUtility.GetPrefabInstanceStatus(obj) == PrefabInstanceStatus.Connected)
             {
-                Object prefab = PrefabUtility.GetCorrespondingObjectFromSource(obj);
+                Object prefab = PrefabUtility.GetCorrespondingObjectFromOriginalSource(obj);
                 path = AssetDatabase.GetAssetPath(prefab);   
             }
 

--- a/com.unity.hlod/Editor/Utils/ObjectUtils.cs
+++ b/com.unity.hlod/Editor/Utils/ObjectUtils.cs
@@ -99,9 +99,10 @@ namespace Unity.HLODSystem.Utils
             GameObject candidate = target;
             GameObject outermost = PrefabUtility.GetOutermostPrefabInstanceRoot(target);
 
-            while (Equals(target,outermost) == false && Equals(target, hlodRoot) == false)
+            while (Equals(target,outermost) == false && 
+                   Equals(GetParent(target), hlodRoot) == false)    //< HLOD root should not be included.
             {
-                target = target.transform.parent.gameObject;
+                target = GetParent(target);
                 if (PrefabUtility.IsAnyPrefabInstanceRoot(target))
                 {
                     candidate = target;
@@ -110,6 +111,12 @@ namespace Unity.HLODSystem.Utils
 
             return candidate;
         }
+
+        private static GameObject GetParent(GameObject go)
+        {
+            return go.transform.parent.gameObject;
+        }
+        
         
         
         


### PR DESCRIPTION
### Purpose of this PR
If the HLOD component is the root of the prefab, it is not created correctly.
Trying to create HLOD only with prefabs with HLOD root.

---
### Release Notes
Fixed to HLOD component is created correctly when it is at the root of the Prefab.

---
### Testing status
Manual test
Passed unit tests.

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: Low

---
### Comments to reviewers
