### PR TITLE
Fixed HLODControllerBase might not be deleted.

### DIFF
--- a/com.unity.hlod/Editor/HLODCreator.cs
+++ b/com.unity.hlod/Editor/HLODCreator.cs
@@ -326,6 +326,7 @@ namespace Unity.HLODSystem
                         InteractionMode.AutomatedAction);
                 }
 
+                var controllers = hlod.GetHLODControllerBases();
                 var generatedObjects = hlod.GeneratedObjects;
                 for (int i = 0; i < generatedObjects.Count; ++i)
                 {
@@ -346,6 +347,15 @@ namespace Unity.HLODSystem
                     EditorUtility.DisplayProgressBar("Destroy HLOD", "Destrying HLOD files", (float)i / (float)generatedObjects.Count);
                 }
                 generatedObjects.Clear();
+
+                //If the controller was created in the old version, must manually delete it.
+                for (int i = 0; i < controllers.Count; ++i)
+                {
+                    if (controllers[i] == null)
+                        continue;
+
+                    Object.DestroyImmediate(controllers[i]);
+                }
             }
             finally
             {

--- a/com.unity.hlod/Runtime/HLOD.cs
+++ b/com.unity.hlod/Runtime/HLOD.cs
@@ -148,6 +148,17 @@ namespace Unity.HLODSystem
                 if ( controllerBase != null )
                     controllerBases.Add(controllerBase);
             }
+            
+            //if controller base doesn't exists in the generated objects, it was created from old version.
+            //so adding controller base manually.
+            if (controllerBases.Count == 0)
+            {
+                var controller = GetComponent<Streaming.HLODControllerBase>();
+                if (controller != null)
+                {
+                    controllerBases.Add(controller);
+                }
+            }
             return controllerBases;
         }
 #endif


### PR DESCRIPTION
### Purpose of this PR
HLODControllerBase may not be deleted when destroying HLODs created in old versions.
So, try to delete the HLODControllerBase one more time in the same way that it was deleted in the previous version.

---
### Release Notes
Fixed HLODControllerBase might not be deleted.

---
### Testing status
All unit tests are passed.
I did manual test.

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: None

---
### Comments to reviewers

