### PR TITLE
Support multiple CameraRecognizer

### DIFF
--- a/com.unity.hlod/Editor/HLODCameraRecognizerEditor.cs
+++ b/com.unity.hlod/Editor/HLODCameraRecognizerEditor.cs
@@ -17,7 +17,7 @@ namespace Unity.HLODSystem
                 GUIStyle style = new GUIStyle();
                 style.fontSize = 15;
                 style.normal.textColor = Color.blue;
-                EditorGUILayout.LabelField("Actived HLODCameraRecognizer.", style);
+                EditorGUILayout.LabelField("Activated HLODCameraRecognizer.", style);
             }
 
             if (GUILayout.Button("Active"))

--- a/com.unity.hlod/Editor/HLODCameraRecognizerEditor.cs
+++ b/com.unity.hlod/Editor/HLODCameraRecognizerEditor.cs
@@ -1,0 +1,32 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Unity.HLODSystem
+{
+    [CustomEditor(typeof(HLODCameraRecognizer))]
+    public class HLODCameraRecognizerEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            
+            var recognizer = target as HLODCameraRecognizer;
+
+            if (HLODCameraRecognizerManager.ActiveRecognizer == recognizer)
+            {
+                GUIStyle style = new GUIStyle();
+                style.fontSize = 15;
+                style.normal.textColor = Color.blue;
+                EditorGUILayout.LabelField("Actived HLODCameraRecognizer.", style);
+            }
+
+            if (GUILayout.Button("Active"))
+            {
+                if (recognizer == null)
+                    return;
+                
+                recognizer.Active();
+            }
+        }
+    }
+}

--- a/com.unity.hlod/Editor/HLODCameraRecognizerEditor.cs.meta
+++ b/com.unity.hlod/Editor/HLODCameraRecognizerEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d65b70e8f6ee4bc8b150a8ea5cbce86c
+timeCreated: 1676016805

--- a/com.unity.hlod/Runtime/HLODCameraRecognizer.cs
+++ b/com.unity.hlod/Runtime/HLODCameraRecognizer.cs
@@ -5,24 +5,57 @@ namespace Unity.HLODSystem
 {
     public class HLODCameraRecognizer : MonoBehaviour
     {
-        private static HLODCameraRecognizer s_instance;
-        private static Camera s_recognizedCamera;
-        public static HLODCameraRecognizer Instance => s_instance;
-        public static Camera RecognizedCamera => s_recognizedCamera;
+        private Camera m_recognizedCamera;
+        public Camera RecognizedCamera => m_recognizedCamera;
+
+        [SerializeField]
+        private int m_id;
+        [SerializeField]
+        private int m_priority;
+
+
+        public int ID
+        {
+            get
+            {
+                return m_id;
+            }
+        }
+
+        public int Priority
+        {
+            get
+            {
+                return m_priority;
+            }
+        }
+        
+        
 
         private void Awake()
         {
-            s_instance = this;
-            s_recognizedCamera = GetComponent<Camera>();
+            
+            m_recognizedCamera = GetComponent<Camera>();
+        }
+        private void OnEnable()
+        {
+            HLODCameraRecognizerManager.Instance.RegisterRecognizer(this);
         }
 
-        private void OnDestroy()
+        private void OnDisable()
         {
-            if (s_instance == this)
+            HLODCameraRecognizerManager.Instance.UnregisterRecognizer(this);            
+        }
+        
+        public void Active()
+        {
+            if (enabled == false)
             {
-                s_instance = null;
-                s_recognizedCamera = null;
+                Debug.LogError("Failed to active HLODCameraRecognizer. It is not Enabled.");
+                return;
             }
+
+            HLODCameraRecognizerManager.Instance.Active(this);
         }
     }
 }

--- a/com.unity.hlod/Runtime/HLODManager.cs
+++ b/com.unity.hlod/Runtime/HLODManager.cs
@@ -76,7 +76,7 @@ namespace Unity.HLODSystem
             }
             else
             {
-                if (cam != HLODCameraRecognizer.RecognizedCamera)
+                if (cam != HLODCameraRecognizerManager.ActiveCamera)
                     return;
             }
 #else

--- a/com.unity.hlod/Runtime/HLODcameraRecognizerManager.cs
+++ b/com.unity.hlod/Runtime/HLODcameraRecognizerManager.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Unity.HLODSystem
+{
+    public class HLODCameraRecognizerManager
+    {
+        private static HLODCameraRecognizerManager s_instance; 
+        public static HLODCameraRecognizerManager Instance
+        {
+            get
+            {
+                if (s_instance == null)
+                    s_instance = new HLODCameraRecognizerManager();
+                return s_instance;
+            }
+        }
+
+        public static HLODCameraRecognizer ActiveRecognizer
+        {
+            get
+            {
+                var instance = Instance;
+                if (instance.m_activeRecognizer == null)
+                {
+                    instance.ActiveHighestPriority();
+                }
+
+                return Instance.m_activeRecognizer;
+            }
+        }
+        public static Camera ActiveCamera
+        {
+            get
+            {
+                var instance = Instance;
+                var regocnizer = ActiveRecognizer;
+                if (regocnizer == null)
+                    return null;
+
+                return ActiveRecognizer.RecognizedCamera;
+            }
+        }
+
+        private bool m_enableAutoHighestPrioritySetting = true;
+        private HLODCameraRecognizer m_activeRecognizer = null;
+        private List<HLODCameraRecognizer> m_recognizers = new List<HLODCameraRecognizer>();
+        
+        public void RegisterRecognizer(HLODCameraRecognizer recognizer)
+        {
+            m_recognizers.Add(recognizer);
+            m_recognizers.Sort((lhs, rhs) =>
+            {
+                //sort in descending order
+                return rhs.Priority - lhs.Priority;
+            });
+            
+            if ( m_enableAutoHighestPrioritySetting )
+                ActiveHighestPriority();
+        }
+
+        public void UnregisterRecognizer(HLODCameraRecognizer recognizer)
+        {
+            m_recognizers.Remove(recognizer);
+
+            if (m_activeRecognizer == recognizer)
+            {
+                m_activeRecognizer = null;
+                ActiveHighestPriority();
+            }
+        }
+
+        public void Active(HLODCameraRecognizer recognizer)
+        {
+            m_activeRecognizer = recognizer;
+            m_enableAutoHighestPrioritySetting = false;
+        }
+
+        public void Active(int id)
+        {
+            for (int i = 0; i < m_recognizers.Count; ++i)
+            {
+                if (m_recognizers[i].ID == id)
+                {
+                    Active(m_recognizers[i]);
+                    return;
+                }
+            }
+        }
+
+        public void ActiveHighestPriority()
+        {
+            if (m_recognizers.Count > 0)
+            {
+                m_activeRecognizer = m_recognizers[0];
+            }
+        }
+
+        public void EnableAutoHighestPrioritySetting(bool enable)
+        {
+            m_enableAutoHighestPrioritySetting = enable;
+            
+            if ( enable )
+                ActiveHighestPriority();
+        }
+
+    }
+}

--- a/com.unity.hlod/Runtime/HLODcameraRecognizerManager.cs
+++ b/com.unity.hlod/Runtime/HLODcameraRecognizerManager.cs
@@ -26,19 +26,18 @@ namespace Unity.HLODSystem
                     instance.ActiveHighestPriority();
                 }
 
-                return Instance.m_activeRecognizer;
+                return instance.m_activeRecognizer;
             }
         }
         public static Camera ActiveCamera
         {
             get
             {
-                var instance = Instance;
-                var regocnizer = ActiveRecognizer;
-                if (regocnizer == null)
+                var recognizer = ActiveRecognizer;
+                if (recognizer == null)
                     return null;
 
-                return ActiveRecognizer.RecognizedCamera;
+                return recognizer.RecognizedCamera;
             }
         }
 

--- a/com.unity.hlod/Runtime/HLODcameraRecognizerManager.cs.meta
+++ b/com.unity.hlod/Runtime/HLODcameraRecognizerManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1aa44d7cc1f445b595cd7f2466a37f92
+timeCreated: 1675907212


### PR DESCRIPTION
### Purpose of this PR
HLODSystem can have only one activate camera. If you want to use multi camera like cutscene, HLOD shows depending on the main camera. So we need a way to control change camera recognizing at runtime.

![image](https://user-images.githubusercontent.com/39615342/218680895-f0afe8c4-5cb3-4f28-9aa2-d5fc442c72b0.png)

![image](https://user-images.githubusercontent.com/39615342/218680792-35c0b22f-cdab-4664-bdad-0aac641a67c8.png)

Added ID and Priority in the HLODCameraRecognizer. You can control recognizer through these values.

Also, added manager calss, HLODCameraRecognizerManager.  You can select the CameraRecognizer to be activated through the following method.

`public void Active(HLODCameraRecognizer recognizer)`
`public void Active(int id)`
`public void ActiveHighestPriority()`
`public void EnableAutoHighestPrioritySetting(bool enable)`

The legacy code works the same as before without any edit.

---
### Release Notes
Support multiple CameraRecognizer

---
### Testing status
Manual 

---
### Overall Product Risks
**Technical Risk**: Medium

**Halo Effect**: Medium

---
### Comments to reviewers
Notes for the reviewers you have assigned.
