### PR TITLE
fix: terrain hlod null reference exception

### DIFF
--- a/com.unity.hlod/Editor/Batcher/SimpleBatcher.cs
+++ b/com.unity.hlod/Editor/Batcher/SimpleBatcher.cs
@@ -23,10 +23,11 @@ namespace Unity.HLODSystem
             BatcherTypes.RegisterBatcherType(typeof(SimpleBatcher));
         }
 
-        private DisposableDictionary<TexturePacker.TextureAtlas, WorkingMaterial> m_createdMaterials = new DisposableDictionary<TexturePacker.TextureAtlas, WorkingMaterial>();
+        private DisposableDictionary<TexturePacker.TextureAtlas, WorkingMaterial> m_createdMaterials =
+            new DisposableDictionary<TexturePacker.TextureAtlas, WorkingMaterial>();
+
         private SerializableDynamicObject m_batcherOptions;
-        
-        
+
 
         [Serializable]
         public class TextureInfo
@@ -60,24 +61,23 @@ namespace Unity.HLODSystem
                 {
                     Combine(rootTransform, packer, targets[i], options);
                     if (onProgress != null)
-                        onProgress(0.5f + ((float)i / (float)targets.Count) * 0.5f);
+                        onProgress(0.5f + ((float) i / (float) targets.Count) * 0.5f);
                 }
             }
-
         }
 
 
         class MaterialTextureCache : IDisposable
         {
             private NativeArray<int> m_detector = new NativeArray<int>(1, Allocator.Persistent);
-            
+
             private List<TextureInfo> m_textureInfoList;
             private DisposableDictionary<string, TexturePacker.MaterialTexture> m_textureCache;
             private DisposableDictionary<PackingType, WorkingTexture> m_defaultTextures;
-                
+
             private bool m_enableTintColor;
             private string m_tintColorName;
-            
+
             public MaterialTextureCache(dynamic options)
             {
                 m_defaultTextures = CreateDefaultTextures();
@@ -86,6 +86,7 @@ namespace Unity.HLODSystem
                 m_textureInfoList = options.TextureInfoList;
                 m_textureCache = new DisposableDictionary<string, TexturePacker.MaterialTexture>();
             }
+
             public TexturePacker.MaterialTexture GetMaterialTextures(WorkingMaterial material)
             {
                 if (m_textureCache.ContainsKey(material.Guid) == false)
@@ -108,7 +109,6 @@ namespace Unity.HLODSystem
                 m_textureCache.Dispose();
                 m_defaultTextures.Dispose();
                 m_detector.Dispose();
-                
             }
 
             private void AddToCache(WorkingMaterial material)
@@ -120,7 +120,7 @@ namespace Unity.HLODSystem
                 {
                     texture = m_defaultTextures[m_textureInfoList[0].Type];
                 }
-                
+
                 TexturePacker.MaterialTexture materialTexture = new TexturePacker.MaterialTexture();
 
                 if (m_enableTintColor)
@@ -136,7 +136,7 @@ namespace Unity.HLODSystem
                 {
                     materialTexture.Add(texture);
                 }
-                
+
 
                 for (int ti = 1; ti < m_textureInfoList.Count; ++ti)
                 {
@@ -153,6 +153,7 @@ namespace Unity.HLODSystem
 
                 m_textureCache.Add(material.Guid, materialTexture);
             }
+
             private void ApplyTintColor(WorkingTexture texture, Color tintColor)
             {
                 for (int ty = 0; ty < texture.Height; ++ty)
@@ -160,12 +161,12 @@ namespace Unity.HLODSystem
                     for (int tx = 0; tx < texture.Width; ++tx)
                     {
                         Color c = texture.GetPixel(tx, ty);
-                    
+
                         c.r = c.r * tintColor.r;
                         c.g = c.g * tintColor.g;
                         c.b = c.b * tintColor.b;
                         c.a = c.a * tintColor.a;
-                    
+
                         texture.SetPixel(tx, ty, c);
                     }
                 }
@@ -173,7 +174,8 @@ namespace Unity.HLODSystem
 
             private static DisposableDictionary<PackingType, WorkingTexture> CreateDefaultTextures()
             {
-                DisposableDictionary<PackingType, WorkingTexture> textures = new DisposableDictionary<PackingType, WorkingTexture>();
+                DisposableDictionary<PackingType, WorkingTexture> textures =
+                    new DisposableDictionary<PackingType, WorkingTexture>();
 
                 textures.Add(PackingType.White, CreateEmptyTexture(4, 4, Color.white, false));
                 textures.Add(PackingType.Black, CreateEmptyTexture(4, 4, Color.black, false));
@@ -181,11 +183,11 @@ namespace Unity.HLODSystem
 
                 return textures;
             }
-
         }
 
-        private void PackingTexture(TexturePacker packer, DisposableList<HLODBuildInfo> targets, dynamic options, Action<float> onProgress)
-        { 
+        private void PackingTexture(TexturePacker packer, DisposableList<HLODBuildInfo> targets, dynamic options,
+            Action<float> onProgress)
+        {
             List<TextureInfo> textureInfoList = options.TextureInfoList;
             using (MaterialTextureCache cache = new MaterialTextureCache(options))
             {
@@ -222,7 +224,7 @@ namespace Unity.HLODSystem
             }
 
             packer.Pack(TextureFormat.RGBA32, options.PackTextureSize, options.LimitTextureSize, false);
-            if ( onProgress != null) onProgress(0.3f);
+            if (onProgress != null) onProgress(0.3f);
 
             int index = 1;
             var atlases = packer.GetAllAtlases();
@@ -240,7 +242,7 @@ namespace Unity.HLODSystem
 
                     textures.Add(textureInfoList[i].OutputName, wt);
                 }
-                
+
                 WorkingMaterial mat = CreateMaterial(options.MaterialGUID, textures);
                 mat.Name = "CombinedMaterial " + index;
                 m_createdMaterials.Add(atlas, mat);
@@ -265,12 +267,12 @@ namespace Unity.HLODSystem
             {
                 material = new WorkingMaterial(Allocator.Persistent, new Material(Shader.Find("Standard")));
             }
-            
+
             foreach (var texture in textures)
             {
                 material.AddTexture(texture.Key, texture.Value.Clone());
             }
-            
+
             return material;
         }
 
@@ -286,7 +288,7 @@ namespace Unity.HLODSystem
 
             for (int i = 0; i < info.WorkingObjects.Count; ++i)
             {
-                var obj = info.WorkingObjects[i]; 
+                var obj = info.WorkingObjects[i];
                 ConvertMesh(obj.Mesh, obj.Materials, atlas, textureInfoList[0].InputName);
 
                 for (int si = 0; si < obj.Mesh.subMeshCount; ++si)
@@ -294,19 +296,19 @@ namespace Unity.HLODSystem
                     var ci = new MeshCombiner.CombineInfo();
                     var colliderLocalToWorld = obj.LocalToWorld;
                     var matrix = hlodWorldToLocal * colliderLocalToWorld;
-                    
+
                     ci.Mesh = obj.Mesh;
                     ci.MeshIndex = si;
-                    
+
                     ci.Transform = matrix;
 
                     if (ci.Mesh == null)
                         continue;
-                    
+
                     combineInfos.Add(ci);
                 }
             }
-            
+
             MeshCombiner combiner = new MeshCombiner();
             WorkingMesh combinedMesh = combiner.CombineMesh(Allocator.Persistent, combineInfos);
 
@@ -324,7 +326,8 @@ namespace Unity.HLODSystem
         }
 
 
-        private void ConvertMesh(WorkingMesh mesh, DisposableList<WorkingMaterial> materials, TexturePacker.TextureAtlas atlas, string mainTextureName)
+        private void ConvertMesh(WorkingMesh mesh, DisposableList<WorkingMaterial> materials,
+            TexturePacker.TextureAtlas atlas, string mainTextureName)
         {
             var uv = mesh.uv;
             var updated = new bool[uv.Length];
@@ -335,11 +338,11 @@ namespace Unity.HLODSystem
                 int[] indices = mesh.GetTriangles(mi);
                 foreach (var i in indices)
                 {
-                    if ( updated[i] == false )
+                    if (updated[i] == false)
                     {
                         var uvCoord = uv[i];
                         var texture = materials[mi].GetTexture(mainTextureName);
-                        
+
                         if (texture == null || texture.GetGUID() == Guid.Empty)
                         {
                             // Sample at center of white texture to avoid sampling edge colors incorrectly
@@ -349,26 +352,25 @@ namespace Unity.HLODSystem
                         else
                         {
                             var uvOffset = atlas.GetUV(texture.GetGUID());
-                            
+
                             uvCoord.x = Mathf.Lerp(uvOffset.xMin, uvOffset.xMax, uvCoord.x);
                             uvCoord.y = Mathf.Lerp(uvOffset.yMin, uvOffset.yMax, uvCoord.y);
                         }
-                        
+
                         uv[i] = uvCoord;
                         updated[i] = true;
                     }
                 }
-                
             }
 
             mesh.uv = uv;
         }
 
 
-     
         static private WorkingTexture CreateEmptyTexture(int width, int height, Color color, bool linear)
         {
-            WorkingTexture texture = new WorkingTexture(Allocator.Persistent, TextureFormat.RGB24, width, height, linear);
+            WorkingTexture texture =
+                new WorkingTexture(Allocator.Persistent, TextureFormat.RGB24, width, height, linear);
 
             for (int y = 0; y < height; ++y)
             {
@@ -380,19 +382,21 @@ namespace Unity.HLODSystem
 
             return texture;
         }
-        
+
         static class Styles
         {
             public static int[] PackTextureSizes = new int[]
             {
                 256, 512, 1024, 2048, 4096
             };
+
             public static string[] PackTextureSizeNames;
 
             public static int[] LimitTextureSizes = new int[]
             {
                 32, 64, 128, 256, 512, 1024
             };
+
             public static string[] LimitTextureSizeNames;
 
 
@@ -415,9 +419,10 @@ namespace Unity.HLODSystem
         private static string[] inputTexturePropertyNames = null;
         private static string[] outputTexturePropertyNames = null;
         private static TextureInfo addingTextureInfo = new TextureInfo();
+
         public static void OnGUI(HLOD hlod, bool isFirst)
         {
-            if (isFirst )
+            if (isFirst)
             {
                 inputTexturePropertyNames = null;
                 outputTexturePropertyNames = null;
@@ -448,8 +453,12 @@ namespace Unity.HLODSystem
             if (batcherOptions.TintColorName == null)
                 batcherOptions.TintColorName = "";
 
-            batcherOptions.PackTextureSize = EditorGUILayout.IntPopup("Pack texture size", batcherOptions.PackTextureSize, Styles.PackTextureSizeNames, Styles.PackTextureSizes);
-            batcherOptions.LimitTextureSize = EditorGUILayout.IntPopup("Limit texture size", batcherOptions.LimitTextureSize, Styles.LimitTextureSizeNames, Styles.LimitTextureSizes);
+            batcherOptions.PackTextureSize = EditorGUILayout.IntPopup("Pack texture size",
+                batcherOptions.PackTextureSize,
+                Styles.PackTextureSizeNames, Styles.PackTextureSizes);
+            batcherOptions.LimitTextureSize = EditorGUILayout.IntPopup("Limit texture size",
+                batcherOptions.LimitTextureSize,
+                Styles.LimitTextureSizeNames, Styles.LimitTextureSizes);
 
             Material mat = null;
 
@@ -460,35 +469,38 @@ namespace Unity.HLODSystem
                 path = AssetDatabase.GUIDToAssetPath(matGUID);
                 mat = AssetDatabase.LoadAssetAtPath<Material>(path);
             }
+
             mat = EditorGUILayout.ObjectField("Material", mat, typeof(Material), false) as Material;
-            if( mat == null)
+            if (mat == null)
                 mat = new Material(Shader.Find("Standard"));
-            
+
             path = AssetDatabase.GetAssetPath(mat);
             matGUID = AssetDatabase.AssetPathToGUID(path);
-            
+
 
             if (matGUID != batcherOptions.MaterialGUID)
             {
                 batcherOptions.MaterialGUID = matGUID;
                 outputTexturePropertyNames = mat.GetTexturePropertyNames();
             }
+
             if (inputTexturePropertyNames == null)
             {
                 inputTexturePropertyNames = GetAllMaterialTextureProperties(hlod.gameObject);
             }
+
             if (outputTexturePropertyNames == null)
             {
                 outputTexturePropertyNames = mat.GetTexturePropertyNames();
             }
-            
+
             //apply tint color
             batcherOptions.EnableTintColor =
                 EditorGUILayout.Toggle("Enable tint color", batcherOptions.EnableTintColor);
             if (batcherOptions.EnableTintColor == true)
             {
                 EditorGUI.indentLevel += 1;
-                
+
                 var shader = mat.shader;
                 List<string> colorPropertyNames = new List<string>();
                 int propertyCount = ShaderUtil.GetPropertyCount(shader);
@@ -511,7 +523,7 @@ namespace Unity.HLODSystem
                 {
                     batcherOptions.TintColorName = "";
                 }
-                
+
                 EditorGUI.indentLevel -= 1;
             }
 
@@ -535,7 +547,7 @@ namespace Unity.HLODSystem
 
                 info.InputName = StringPopup(info.InputName, inputTexturePropertyNames);
                 info.OutputName = StringPopup(info.OutputName, outputTexturePropertyNames);
-                info.Type = (PackingType)EditorGUILayout.EnumPopup(info.Type);
+                info.Type = (PackingType) EditorGUILayout.EnumPopup(info.Type);
 
                 if (i == 0)
                     GUI.enabled = false;
@@ -544,6 +556,7 @@ namespace Unity.HLODSystem
                     batcherOptions.TextureInfoList.RemoveAt(i);
                     i -= 1;
                 }
+
                 if (i == 0)
                     GUI.enabled = true;
                 EditorGUILayout.EndHorizontal();
@@ -566,6 +579,7 @@ namespace Unity.HLODSystem
                 inputTexturePropertyNames = null;
                 outputTexturePropertyNames = null;
             }
+
             EditorGUILayout.EndHorizontal();
 
             EditorGUI.indentLevel -= 1;
@@ -595,21 +609,17 @@ namespace Unity.HLODSystem
             for (int m = 0; m < meshRenderers.Length; ++m)
             {
                 var mesh = meshRenderers[m];
-                foreach (Material material in mesh.sharedMaterials)
+                foreach (var material in mesh.sharedMaterials)
                 {
                     var names = material.GetTexturePropertyNames();
                     for (int n = 0; n < names.Length; ++n)
                     {
                         texturePropertyNames.Add(names[n]);
-                    }    
+                    }
                 }
-                
             }
 
             return texturePropertyNames.ToArray();
         }
-
-
     }
-
 }

--- a/com.unity.hlod/Editor/SpaceManager/QuadTreeSpaceSplitter.cs
+++ b/com.unity.hlod/Editor/SpaceManager/QuadTreeSpaceSplitter.cs
@@ -18,9 +18,9 @@ namespace Unity.HLODSystem.SpaceManager
                    (double) bounds.max.z <= (double) target.max.z;
         }
     }
+
     public class QuadTreeSpaceSplitter : ISpaceSplitter
     {
-        
         [InitializeOnLoadMethod]
         static void RegisterType()
         {
@@ -31,7 +31,7 @@ namespace Unity.HLODSystem.SpaceManager
 
         private bool m_useSubHLODTree;
         private float m_subHLODTreeSize;
-        
+
 
         public QuadTreeSpaceSplitter(SerializableDynamicObject spaceSplitterOptions)
         {
@@ -39,27 +39,26 @@ namespace Unity.HLODSystem.SpaceManager
 
             m_useSubHLODTree = false;
             m_subHLODTreeSize = 0.0f;
-            
+
             if (spaceSplitterOptions == null)
             {
                 return;
             }
-            
+
             dynamic options = spaceSplitterOptions;
-            if(options.LooseSize1 != null)
+            if (options.LooseSize1 != null)
                 m_looseSizeFromOptions = options.LooseSize;
-            if(options.UseSubHLODTree != null)
+            if (options.UseSubHLODTree != null)
                 m_useSubHLODTree = options.UseSubHLODTree;
-            if(options.SubHLODTreeSize != null)
+            if (options.SubHLODTreeSize != null)
                 m_subHLODTreeSize = options.SubHLODTreeSize;
-            
         }
 
         public int CalculateSubTreeCount(Bounds bounds)
         {
             if (m_useSubHLODTree == false)
                 return 1;
-            
+
             List<Bounds> splittedBounds = SplitBounds(bounds, m_subHLODTreeSize);
             return splittedBounds.Count;
         }
@@ -76,7 +75,7 @@ namespace Unity.HLODSystem.SpaceManager
                 }
                 else
                 {
-                    maxLength = Mathf.Max(bounds.extents.x, bounds.extents.z);    
+                    maxLength = Mathf.Max(bounds.extents.x, bounds.extents.z);
                 }
             }
             else
@@ -99,6 +98,7 @@ namespace Unity.HLODSystem.SpaceManager
             List<GameObject> targetObjects, Action<float> onProgress)
         {
             List<SpaceNode> nodes = new List<SpaceNode>();
+
             List<TargetInfo> targetInfos = CreateTargetInfoList(targetObjects, transform);
 
             if (m_useSubHLODTree == true)
@@ -106,7 +106,7 @@ namespace Unity.HLODSystem.SpaceManager
                 List<Bounds> splittedBounds = SplitBounds(initBounds, m_subHLODTreeSize);
                 List<List<TargetInfo>> splittedTargetInfos = SplitTargetObjects(targetInfos, splittedBounds);
 
-                float progressSize = 1.0f / splittedTargetInfos.Count; 
+                float progressSize = 1.0f / splittedTargetInfos.Count;
                 for (int i = 0; i < splittedTargetInfos.Count; ++i)
                 {
                     nodes.Add(CreateSpaceTreeImpl(splittedBounds[i], chunkSize, splittedTargetInfos[i], (p =>
@@ -123,34 +123,35 @@ namespace Unity.HLODSystem.SpaceManager
 
             return nodes;
         }
-        private SpaceNode CreateSpaceTreeImpl(Bounds initBounds, float chunkSize, List<TargetInfo> targetObjects, Action<float> onProgress)
+
+        private SpaceNode CreateSpaceTreeImpl(Bounds initBounds, float chunkSize, List<TargetInfo> targetObjects,
+            Action<float> onProgress)
         {
             float looseSize = CalcLooseSize(chunkSize);
             SpaceNode rootNode = new SpaceNode();
             rootNode.Bounds = initBounds;
 
-            if ( onProgress != null)
+            if (onProgress != null)
                 onProgress(0.0f);
 
-			//space split first
-			Stack<SpaceNode> nodeStack = new Stack<SpaceNode>();
-			nodeStack.Push(rootNode);
-		
-			while(nodeStack.Count > 0 )
-			{
-				SpaceNode node = nodeStack.Pop();
-				if ( node.Bounds.size.x > chunkSize )
-				{
+            //space split first
+            Stack<SpaceNode> nodeStack = new Stack<SpaceNode>();
+            nodeStack.Push(rootNode);
+
+            while (nodeStack.Count > 0)
+            {
+                SpaceNode node = nodeStack.Pop();
+                if (node.Bounds.size.x > chunkSize)
+                {
                     List<SpaceNode> childNodes = CreateChildSpaceNodes(node, looseSize);
-					
-					for ( int i = 0; i < childNodes.Count; ++i )
+
+                    for (int i = 0; i < childNodes.Count; ++i)
                     {
                         childNodes[i].ParentNode = node;
-						nodeStack.Push(childNodes[i]);
-					}
-						
-				}
-			}
+                        nodeStack.Push(childNodes[i]);
+                    }
+                }
+            }
 
             if (targetObjects == null)
                 return rootNode;
@@ -194,12 +195,12 @@ namespace Unity.HLODSystem.SpaceManager
 
                     target.Objects.Add(targetObjects[oi].GameObject);
                     break;
-                }        
-                
-                if ( onProgress != null)
-                    onProgress((float)oi/ (float)targetObjects.Count);
+                }
+
+                if (onProgress != null)
+                    onProgress((float) oi / (float) targetObjects.Count);
             }
-            
+
             return rootNode;
         }
 
@@ -211,12 +212,17 @@ namespace Unity.HLODSystem.SpaceManager
 
         private List<TargetInfo> CreateTargetInfoList(List<GameObject> gameObjects, Transform transform)
         {
+            if (gameObjects == null)
+            {
+                return new List<TargetInfo>(0);
+            }
+
             List<TargetInfo> targetInfos = new List<TargetInfo>(gameObjects.Count);
 
             for (int i = 0; i < gameObjects.Count; ++i)
             {
                 Bounds? bounds = CalculateBounds(gameObjects[i], transform);
-                if ( bounds == null )
+                if (bounds == null)
                     continue;
                 targetInfos.Add(new TargetInfo()
                 {
@@ -253,7 +259,7 @@ namespace Unity.HLODSystem.SpaceManager
 
             List<Bounds> boundsList = new List<Bounds>();
             Vector3 splitBoundSize = new Vector3(xsize, bounds.size.y, zsize);
-            
+
             for (int z = 0; z < zcount; ++z)
             {
                 for (int x = 0; x < xcount; ++x)
@@ -262,8 +268,8 @@ namespace Unity.HLODSystem.SpaceManager
                         x * xsize + xsize * 0.5f,
                         bounds.extents.y,
                         z * zsize + zsize * 0.5f) + bounds.min;
-                    
-                    boundsList.Add(new Bounds(center,splitBoundSize));
+
+                    boundsList.Add(new Bounds(center, splitBoundSize));
                 }
             }
 
@@ -298,15 +304,13 @@ namespace Unity.HLODSystem.SpaceManager
             //If the chunk size is small, there is a problem that it may get caught in an infinite loop.
             //So, the size can be determined according to the chunk size.
             return Mathf.Min(chunkSize * 0.3f, m_looseSizeFromOptions);
-            
         }
 
-        
 
         private List<SpaceNode> CreateChildSpaceNodes(SpaceNode parentNode, float looseSize)
         {
             List<SpaceNode> childSpaceNodes = new List<SpaceNode>(4);
-            
+
             float size = parentNode.Bounds.size.x;
             float extend = size * 0.5f;
             float offset = extend * 0.5f;
@@ -330,7 +334,7 @@ namespace Unity.HLODSystem.SpaceManager
                 SpaceNode.CreateSpaceNodeWithBounds(
                     new Bounds(center + new Vector3(offset, 0.0f, offset), looseBoundsSize)
                 ));
-            
+
             return childSpaceNodes;
         }
 
@@ -373,10 +377,6 @@ namespace Unity.HLODSystem.SpaceManager
                 options.SubHLODTreeSize = EditorGUILayout.FloatField("Sub tree size", options.SubHLODTreeSize);
                 EditorGUI.indentLevel -= 1;
             }
-
         }
-
-        
     }
-
 }

--- a/com.unity.hlod/Editor/TerrainHLODCreator.cs
+++ b/com.unity.hlod/Editor/TerrainHLODCreator.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using Unity.Collections;
 using Unity.HLODSystem.Simplifier;
@@ -19,11 +18,18 @@ namespace Unity.HLODSystem
 {
     public class TerrainHLODCreator
     {
+        public static IEnumerator Create(TerrainHLOD hlod, Action callback)
+        {
+            TerrainHLODCreator creator = new TerrainHLODCreator(hlod);
+            yield return creator.CreateImpl(callback);
+        }
+
         public static IEnumerator Create(TerrainHLOD hlod)
         {
             TerrainHLODCreator creator = new TerrainHLODCreator(hlod);
-            yield return creator.CreateImpl();
+            yield return creator.CreateImpl(null);
         }
+
         public static IEnumerator Destroy(TerrainHLOD hlod)
         {
             var controller = hlod.GetComponent<HLODControllerBase>();
@@ -40,7 +46,7 @@ namespace Unity.HLODSystem
                         InteractionMode.AutomatedAction);
                 }
 
-                
+
                 var generatedObjects = hlod.GeneratedObjects;
                 for (int i = 0; i < generatedObjects.Count; ++i)
                 {
@@ -58,8 +64,10 @@ namespace Unity.HLODSystem
                         Object.DestroyImmediate(generatedObjects[i]);
                     }
 
-                    EditorUtility.DisplayProgressBar("Destroy HLOD", "Destroying HLOD files", (float)i / (float)generatedObjects.Count);
+                    EditorUtility.DisplayProgressBar("Destroy HLOD", "Destroying HLOD files",
+                        (float) i / (float) generatedObjects.Count);
                 }
+
                 generatedObjects.Clear();
                 Object.DestroyImmediate(controller);
             }
@@ -67,11 +75,10 @@ namespace Unity.HLODSystem
             {
                 EditorUtility.ClearProgressBar();
             }
-            
+
             EditorUtility.SetDirty(hlod.gameObject);
             EditorUtility.SetDirty(hlod);
         }
-
 
 
         class Layer : IDisposable
@@ -79,7 +86,7 @@ namespace Unity.HLODSystem
             private NativeArray<int> m_detector = new NativeArray<int>(1, Allocator.Persistent);
 
             public float NormalScale => m_normalScale;
-            
+
             public Layer(TerrainLayer layer, float chunkSize)
             {
                 m_diffuseTextures = new DisposableList<WorkingTexture>();
@@ -92,12 +99,24 @@ namespace Unity.HLODSystem
 
                 m_chunkSize = chunkSize;
 
-                MakeTexture(layer, layer.diffuseTexture, layer.diffuseRemapMin, layer.diffuseRemapMax, m_diffuseTextures);
-                MakeTexture(layer, layer.maskMapTexture, layer.maskMapRemapMin, layer.maskMapRemapMax, m_maskTextures);
-                MakeTexture(layer, layer.normalMapTexture, Vector4.zero, Vector4.one, m_normalTextures);
+
+                MakeTexture(layer, layer.diffuseTexture, layer.diffuseRemapMin, layer.diffuseRemapMax,
+                    m_diffuseTextures);
+
+                if (layer.maskMapTexture)
+                {
+                    MakeTexture(layer, layer.maskMapTexture, layer.maskMapRemapMin, layer.maskMapRemapMax,
+                        m_maskTextures);
+                }
+
+                if (layer.normalMapTexture)
+                {
+                    MakeTexture(layer, layer.normalMapTexture, Vector4.zero, Vector4.one, m_normalTextures);
+                }
             }
 
-            void MakeTexture(TerrainLayer layer, Texture2D texture, Vector4 min, Vector4 max, DisposableList<WorkingTexture> results)
+            void MakeTexture(TerrainLayer layer, Texture2D texture, Vector4 min, Vector4 max,
+                DisposableList<WorkingTexture> results)
             {
                 bool linear = !GraphicsFormatUtility.IsSRGBFormat(texture.graphicsFormat);
 
@@ -135,7 +154,8 @@ namespace Unity.HLODSystem
                     {
                         int width = texture.width >> i;
                         int height = texture.height >> i;
-                        WorkingTexture workingTexture = new WorkingTexture(Allocator.Persistent, texture.format, width, height, linear);
+                        WorkingTexture workingTexture =
+                            new WorkingTexture(Allocator.Persistent, texture.format, width, height, linear);
                         Color[] colors = texture.GetPixels(i);
                         for (int y = 0; y < height; ++y)
                         {
@@ -159,7 +179,7 @@ namespace Unity.HLODSystem
                     }
                 }
             }
-            
+
             public void Dispose()
             {
                 m_diffuseTextures?.Dispose();
@@ -174,7 +194,7 @@ namespace Unity.HLODSystem
                 v = v - Mathf.Floor(v);
 
                 mipLevel = Mathf.Min(mipLevel, m_diffuseTextures.Count - 1);
-                
+
                 return m_diffuseTextures[mipLevel].GetPixel(u, v);
             }
 
@@ -236,7 +256,7 @@ namespace Unity.HLODSystem
             {
                 int sx = Mathf.Max(source.Width >> 1, 1);
                 int sy = Mathf.Max(source.Height >> 1, 1);
-                
+
                 WorkingTexture mipmap = new WorkingTexture(Allocator.Persistent, source.Format, sx, sy, source.Linear);
                 mipmap.Name = source.Name;
 
@@ -246,7 +266,7 @@ namespace Unity.HLODSystem
                     {
                         Color color = new Color();
 
-                        int x1 = Mathf.Min(x * 2 + 0, source.Width -1);
+                        int x1 = Mathf.Min(x * 2 + 0, source.Width - 1);
                         int x2 = Mathf.Min(x * 2 + 1, source.Width - 1);
                         int y1 = Mathf.Min(y * 2 + 0, source.Height - 1);
                         int y2 = Mathf.Min(y * 2 + 1, source.Height - 1);
@@ -287,7 +307,6 @@ namespace Unity.HLODSystem
             private float m_normalScale;
         }
 
-      
 
         private TerrainHLOD m_hlod;
 
@@ -313,22 +332,24 @@ namespace Unity.HLODSystem
 
         private Heightmap CreateSubHightmap(Bounds bounds)
         {
-            int beginX = Mathf.RoundToInt(bounds.min.x / m_size.x * (m_heightmap.Width-1));
-            int beginZ = Mathf.RoundToInt(bounds.min.z / m_size.z * (m_heightmap.Height-1));
-            int endX = Mathf.RoundToInt(bounds.max.x / m_size.x * (m_heightmap.Width-1));
-            int endZ = Mathf.RoundToInt(bounds.max.z / m_size.z * (m_heightmap.Height-1));
+            int beginX = Mathf.RoundToInt(bounds.min.x / m_size.x * (m_heightmap.Width - 1));
+            int beginZ = Mathf.RoundToInt(bounds.min.z / m_size.z * (m_heightmap.Height - 1));
+            int endX = Mathf.RoundToInt(bounds.max.x / m_size.x * (m_heightmap.Width - 1));
+            int endZ = Mathf.RoundToInt(bounds.max.z / m_size.z * (m_heightmap.Height - 1));
 
             int width = endX - beginX + 1;
             int height = endZ - beginZ + 1;
 
             return m_heightmap.GetHeightmap(beginX, beginZ, width, height);
         }
-        private WorkingObject CreateBakedTerrain(string name, Bounds bounds, Heightmap heightmap, int distance, bool isLeaf)
+
+        private WorkingObject CreateBakedTerrain(string name, Bounds bounds, Heightmap heightmap, int distance,
+            bool isLeaf)
         {
             WorkingObject wo = new WorkingObject(Allocator.Persistent);
             wo.Name = name;
             wo.LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
-            
+
             m_queue.EnqueueJob(() =>
             {
                 WorkingMesh mesh = CreateBakedGeometry(name, heightmap, bounds, distance);
@@ -337,7 +358,7 @@ namespace Unity.HLODSystem
 
             m_queue.EnqueueJob(() =>
             {
-                WorkingMaterial material = CreateBakedMaterial(name, bounds, isLeaf); 
+                WorkingMaterial material = CreateBakedMaterial(name, bounds, isLeaf);
                 wo.Materials.Add(material);
             });
 
@@ -349,7 +370,7 @@ namespace Unity.HLODSystem
         {
             int borderWidth = CalcBorderWidth(heightmap, distance);
             int borderWidth2x = borderWidth * 2;
-            
+
             WorkingMesh mesh =
                 new WorkingMesh(Allocator.Persistent, heightmap.Width * heightmap.Height,
                     (heightmap.Width - borderWidth2x - 1) * (heightmap.Height - borderWidth2x - 1) * 6, 1, 0);
@@ -357,17 +378,18 @@ namespace Unity.HLODSystem
             mesh.name = name + "_Mesh";
 
 
-            Vector3[] vertices =  new Vector3[(heightmap.Width - borderWidth2x) * (heightmap.Height - borderWidth2x)];
+            Vector3[] vertices = new Vector3[(heightmap.Width - borderWidth2x) * (heightmap.Height - borderWidth2x)];
             Vector3[] normals = new Vector3[(heightmap.Width - borderWidth2x) * (heightmap.Height - borderWidth2x)];
             Vector2[] uvs = new Vector2[(heightmap.Width - borderWidth2x) * (heightmap.Height - borderWidth2x)];
-            int[] triangles = new int[(heightmap.Width - borderWidth2x - 1) * (heightmap.Height - borderWidth2x - 1) * 6];
+            int[] triangles =
+                new int[(heightmap.Width - borderWidth2x - 1) * (heightmap.Height - borderWidth2x - 1) * 6];
 
 
             int vi = 0;
             //except boder line
-            for (int z = borderWidth; z < heightmap.Height -borderWidth; ++z)
+            for (int z = borderWidth; z < heightmap.Height - borderWidth; ++z)
             {
-                for (int x = borderWidth; x < heightmap.Width -borderWidth; ++x)
+                for (int x = borderWidth; x < heightmap.Width - borderWidth; ++x)
                 {
                     int index = vi++;
 
@@ -375,12 +397,10 @@ namespace Unity.HLODSystem
                     vertices[index].y = heightmap.Size.y * heightmap[z, x];
                     vertices[index].z = bounds.size.z * (z) / (heightmap.Height - 1) + bounds.min.z;
 
-                    uvs[index].x = (float)x / (heightmap.Width - 1);
-                    uvs[index].y = (float)z / (heightmap.Height - 1);
-                    
+                    uvs[index].x = (float) x / (heightmap.Width - 1);
+                    uvs[index].y = (float) z / (heightmap.Height - 1);
+
                     normals[index] = heightmap.GetInterpolatedNormal(uvs[index].x, uvs[index].y);
-                    
-                    
                 }
             }
 
@@ -389,10 +409,10 @@ namespace Unity.HLODSystem
             {
                 for (int x = 0; x < heightmap.Width - borderWidth2x - 1; ++x)
                 {
-                    int i00 = z * (heightmap.Width -borderWidth2x)+ x;
-                    int i10 = z * (heightmap.Width -borderWidth2x)+ x + 1;
-                    int i01 = (z + 1) * (heightmap.Width -borderWidth2x)+ x;
-                    int i11 = (z + 1) * (heightmap.Width -borderWidth2x)+ x + 1;
+                    int i00 = z * (heightmap.Width - borderWidth2x) + x;
+                    int i10 = z * (heightmap.Width - borderWidth2x) + x + 1;
+                    int i01 = (z + 1) * (heightmap.Width - borderWidth2x) + x;
+                    int i11 = (z + 1) * (heightmap.Width - borderWidth2x) + x + 1;
 
                     triangles[ii + 0] = i00;
                     triangles[ii + 1] = i11;
@@ -463,7 +483,9 @@ namespace Unity.HLODSystem
             return c;
         }
 
-        private void EnqueueBlendTextureJob(WorkingTexture texture, Bounds bounds, int resolution, System.Func<int, float, float, float, float, bool, Color> getColor, System.Func<Color, Color> packColor = null)
+        private void EnqueueBlendTextureJob(WorkingTexture texture, Bounds bounds, int resolution,
+            System.Func<int, float, float, float, float, bool, Color> getColor,
+            System.Func<Color, Color> packColor = null)
         {
             bool linear = texture.Linear;
 
@@ -478,8 +500,8 @@ namespace Unity.HLODSystem
                 {
                     for (int x = 0; x < resolution; ++x)
                     {
-                        float u = (float)x / (float)resolution * usize + ustart;
-                        float v = (float)y / (float)resolution * vsize + vstart;
+                        float u = (float) x / (float) resolution * usize + ustart;
+                        float v = (float) y / (float) resolution * vsize + vstart;
 
                         Color color = new Color(0.0f, 0.0f, 0.0f, 0.0f);
 
@@ -506,8 +528,8 @@ namespace Unity.HLODSystem
                             if (weight < 0.01f)
                                 continue;
 
-                            float wx = (float)x / (float)resolution * bounds.size.x + bounds.min.x;
-                            float wy = (float)y / (float)resolution * bounds.size.z + bounds.min.z;
+                            float wx = (float) x / (float) resolution * bounds.size.x + bounds.min.x;
+                            float wy = (float) y / (float) resolution * bounds.size.z + bounds.min.z;
 
                             Color c = getColor(li, wx, wy, bounds.size.x, bounds.size.z, linear);
 
@@ -536,11 +558,12 @@ namespace Unity.HLODSystem
 
         private WorkingTexture BakeAlbedo(string name, Bounds bounds, int resolution)
         {
-            WorkingTexture albedoTexture = new WorkingTexture(Allocator.Persistent, TextureFormat.RGB24, resolution, resolution, false);
+            WorkingTexture albedoTexture =
+                new WorkingTexture(Allocator.Persistent, TextureFormat.RGB24, resolution, resolution, false);
             albedoTexture.Name = name + "_Albedo";
             albedoTexture.WrapMode = TextureWrapMode.Clamp;
 
-            EnqueueBlendTextureJob(albedoTexture, bounds, resolution, (layer, wx, wz, sx, sz, linear) => 
+            EnqueueBlendTextureJob(albedoTexture, bounds, resolution, (layer, wx, wz, sx, sz, linear) =>
             {
                 Color c = m_layers[layer].GetColorByWorld(wx, wz, sx, sz);
                 if (!linear)
@@ -548,13 +571,14 @@ namespace Unity.HLODSystem
                 return c;
             });
 
-            
+
             return albedoTexture;
         }
 
         private WorkingTexture BakeMask(string name, Bounds bounds, int resolution)
         {
-            WorkingTexture maskTexture = new WorkingTexture(Allocator.Persistent, TextureFormat.ARGB32, resolution, resolution, false);
+            WorkingTexture maskTexture =
+                new WorkingTexture(Allocator.Persistent, TextureFormat.ARGB32, resolution, resolution, false);
             maskTexture.Name = name + "_Mask";
             maskTexture.WrapMode = TextureWrapMode.Clamp;
 
@@ -571,7 +595,8 @@ namespace Unity.HLODSystem
 
         private WorkingTexture BakeNormal(string name, Bounds bounds, int resolution)
         {
-            WorkingTexture normalTexture = new WorkingTexture(Allocator.Persistent, TextureFormat.RGB24, resolution, resolution, true);
+            WorkingTexture normalTexture =
+                new WorkingTexture(Allocator.Persistent, TextureFormat.RGB24, resolution, resolution, true);
             normalTexture.Name = name + "_Normal";
             normalTexture.WrapMode = TextureWrapMode.Clamp;
 
@@ -580,14 +605,14 @@ namespace Unity.HLODSystem
                 Color c = m_layers[layer].GetNormalByWorld(wx, wz, sx, sz);
                 c = UnPackNormal(c, m_layers[layer].NormalScale);
                 return c;
-            },(c) =>
+            }, (c) =>
             {
                 Vector3 n = new Vector3(c.r, c.g, c.b);
                 n.Normalize();
                 c = new Color(n.x, n.y, n.z);
                 return PackNormal(c);
             });
-            
+
             return normalTexture;
         }
 
@@ -619,7 +644,7 @@ namespace Unity.HLODSystem
                     }
                 }
             }
-            
+
 
             return candidates.ToList();
         }
@@ -635,16 +660,16 @@ namespace Unity.HLODSystem
             //generate border vertices
             List<BorderVertex> borderVertices = new List<BorderVertex>((heightmap.Width + heightmap.Height) * 2);
 
-            int xBorderOffset = Mathf.Max((heightmap.Width - 1) / borderCount, 1 );    //< avoid 0
-            int yBorderOffset = Mathf.Max((heightmap.Height - 1) / borderCount, 1);    //< avoid 0
-            
+            int xBorderOffset = Mathf.Max((heightmap.Width - 1) / borderCount, 1); //< avoid 0
+            int yBorderOffset = Mathf.Max((heightmap.Height - 1) / borderCount, 1); //< avoid 0
+
             //upside
-            for (int i = 0; i < heightmap.Width-1; i += xBorderOffset)
+            for (int i = 0; i < heightmap.Width - 1; i += xBorderOffset)
             {
                 float h = heightmap[0, i];
 
                 BorderVertex v;
-                v.Pos.x = (heightmap.Size.x * i) / (heightmap.Width-1);
+                v.Pos.x = (heightmap.Size.x * i) / (heightmap.Width - 1);
                 v.Pos.y = (heightmap.Size.y * h);
                 v.Pos.z = 0.0f;
                 v.Pos += heightmap.Offset;
@@ -655,14 +680,14 @@ namespace Unity.HLODSystem
             }
 
             //rightside
-            for (int i = 0; i < heightmap.Height-1; i += yBorderOffset)
+            for (int i = 0; i < heightmap.Height - 1; i += yBorderOffset)
             {
                 float h = heightmap[i, heightmap.Width - 1];
 
                 BorderVertex v;
                 v.Pos.x = heightmap.Size.x;
                 v.Pos.y = (heightmap.Size.y * h);
-                v.Pos.z = (heightmap.Size.z * i) / (heightmap.Height-1);
+                v.Pos.z = (heightmap.Size.z * i) / (heightmap.Height - 1);
                 v.Pos += heightmap.Offset;
 
                 v.ClosestIndex = -1;
@@ -671,12 +696,12 @@ namespace Unity.HLODSystem
             }
 
             //downside
-            for (int i = heightmap.Width-1; i > 0; i -= xBorderOffset)
+            for (int i = heightmap.Width - 1; i > 0; i -= xBorderOffset)
             {
                 float h = heightmap[heightmap.Height - 1, i];
 
                 BorderVertex v;
-                v.Pos.x = (heightmap.Size.x * i) / (heightmap.Width-1);
+                v.Pos.x = (heightmap.Size.x * i) / (heightmap.Width - 1);
                 v.Pos.y = (heightmap.Size.y * h);
                 v.Pos.z = heightmap.Size.z;
                 v.Pos += heightmap.Offset;
@@ -694,7 +719,7 @@ namespace Unity.HLODSystem
                 BorderVertex v;
                 v.Pos.x = 0.0f;
                 v.Pos.y = (heightmap.Size.y * h);
-                v.Pos.z = (heightmap.Size.z * i) / (heightmap.Height-1);
+                v.Pos.z = (heightmap.Size.z * i) / (heightmap.Height - 1);
                 v.Pos += heightmap.Offset;
 
                 v.ClosestIndex = -1;
@@ -704,7 +729,7 @@ namespace Unity.HLODSystem
 
             return borderVertices;
         }
-        
+
 
         private WorkingMesh MakeBorder(WorkingMesh source, Heightmap heightmap, int borderCount)
         {
@@ -721,15 +746,15 @@ namespace Unity.HLODSystem
                 List<Vector2Int> edges = GetEdgeList(tris);
                 HashSet<int> vertexIndces = new HashSet<int>();
                 List<BorderVertex> edgeVertices = new List<BorderVertex>();
-                
+
                 for (int ei = 0; ei < edges.Count; ++ei)
                 {
                     vertexIndces.Add(edges[ei].x);
                     vertexIndces.Add(edges[ei].y);
                 }
-                
+
                 List<BorderVertex> borderVertices = GenerateBorderVertices(heightmap, borderCount);
-                
+
                 //calculate closest vertex from border vertices.
                 for (int i = 0; i < borderVertices.Count; ++i)
                 {
@@ -748,13 +773,13 @@ namespace Unity.HLODSystem
 
                     borderVertices[i] = v;
                 }
-                
+
                 //generate tris
                 int startAddIndex = vertices.Count;
                 for (int bi = 0; bi < borderVertices.Count; ++bi)
                 {
                     int next = (bi == borderVertices.Count - 1) ? 0 : bi + 1;
-                    
+
                     tris.Add(bi + startAddIndex);
                     tris.Add(borderVertices[bi].ClosestIndex);
                     tris.Add(next + startAddIndex);
@@ -763,19 +788,17 @@ namespace Unity.HLODSystem
                     uv.x = (borderVertices[bi].Pos.x - heightmap.Offset.x) / heightmap.Size.x;
                     uv.y = (borderVertices[bi].Pos.z - heightmap.Offset.z) / heightmap.Size.z;
                     vertices.Add(borderVertices[bi].Pos);
-                    
+
                     normals.Add(heightmap.GetInterpolatedNormal(uv.x, uv.y));
-                    
+
                     uvs.Add(uv);
-                    
+
                     if (borderVertices[bi].ClosestIndex == borderVertices[next].ClosestIndex)
                         continue;
-                    
+
                     tris.Add(borderVertices[bi].ClosestIndex);
                     tris.Add(borderVertices[next].ClosestIndex);
                     tris.Add(next + startAddIndex);
-
-
                 }
 
                 maxTris += tris.Count;
@@ -812,14 +835,16 @@ namespace Unity.HLODSystem
 
             mesh.uv = uvs;
         }
+
         private int CalcBorderWidth(Heightmap heightmap, int distance)
         {
             if (m_hlod.SimplifierType == typeof(Simplifier.None))
             {
                 return 1;
             }
+
             dynamic options = m_hlod.SimplifierOptions;
-            
+
             int maxPolygonCount = options.SimplifyMaxPolygonCount;
             int minPolygonCount = options.SimplifyMinPolygonCount;
             float polygonRatio = options.SimplifyPolygonRatio;
@@ -827,23 +852,23 @@ namespace Unity.HLODSystem
 
             float maxQuality = Mathf.Min((float) maxPolygonCount / (float) triangleCount, polygonRatio);
             float minQuality = Mathf.Max((float) minPolygonCount / (float) triangleCount, 0.0f);
-            
+
             var ratio = maxQuality * Mathf.Pow(polygonRatio, distance);
             ratio = Mathf.Max(ratio, minQuality);
 
-            int expectPolygonCount = (int)(triangleCount * ratio);
+            int expectPolygonCount = (int) (triangleCount * ratio);
 
-            float areaSize = (heightmap.Size.x * heightmap.Size.z); 
-            float sourceSizePerTri = areaSize/  triangleCount;
+            float areaSize = (heightmap.Size.x * heightmap.Size.z);
+            float sourceSizePerTri = areaSize / triangleCount;
             float targetSizePerTri = areaSize / expectPolygonCount;
             float sizeRatio = targetSizePerTri / sourceSizePerTri;
             float sizeRatioSqrt = Mathf.Sqrt(sizeRatio);
-            
+
             //sizeRatioSqrt is little bit big i think.
             //So I adjust the value by divide 2.
             return Mathf.Max((int) sizeRatioSqrt / 2, 1);
         }
-        
+
 
         public class EdgeGroup
         {
@@ -856,13 +881,13 @@ namespace Unity.HLODSystem
         {
             int totalTris = 0;
             List<int[]> newTris = new List<int[]>();
-            
+
             for (int si = 0; si < source.subMeshCount; ++si)
             {
                 List<int> tris = source.GetTriangles(si).ToList();
                 List<Vector2Int> edgeList = GetEdgeList(tris);
-                
-                
+
+
                 List<EdgeGroup> groups = new List<EdgeGroup>();
                 for (int i = 0; i < edgeList.Count; ++i)
                 {
@@ -870,7 +895,7 @@ namespace Unity.HLODSystem
                     group.Begin = edgeList[i].x;
                     group.End = edgeList[i].y;
                     group.EdgeList.Add(edgeList[i]);
-                
+
                     groups.Add(group);
                 }
 
@@ -917,7 +942,7 @@ namespace Unity.HLODSystem
                 for (int gi = 0; gi < groups.Count; ++gi)
                 {
                     EdgeGroup group = groups[gi];
-                    for (int ei1 = 1; ei1 < group.EdgeList.Count-1; ++ei1)
+                    for (int ei1 = 1; ei1 < group.EdgeList.Count - 1; ++ei1)
                     {
                         for (int ei2 = ei1 + 1; ei2 < group.EdgeList.Count; ++ei2)
                         {
@@ -936,7 +961,7 @@ namespace Unity.HLODSystem
                                 {
                                     group.EdgeList.RemoveAt(i);
                                 }
-                                
+
                                 groups.Add(ng);
 
                                 ei1 = 0; // goto first
@@ -948,9 +973,9 @@ namespace Unity.HLODSystem
 
                 if (groups.Count == 0)
                     continue;
-                
+
                 groups.Sort((g1, g2) => { return g2.EdgeList.Count - g1.EdgeList.Count; });
-                
+
                 //first group( longest group ) is outline. 
                 for (int i = 1; i < groups.Count; ++i)
                 {
@@ -961,14 +986,14 @@ namespace Unity.HLODSystem
                         tris.Add(group.EdgeList[ei].y);
                         tris.Add(group.EdgeList[ei].x);
                     }
-                
                 }
 
                 totalTris += tris.Count;
                 newTris.Add(tris.ToArray());
             }
-            
-            WorkingMesh mesh = new WorkingMesh(Allocator.Persistent, source.vertexCount, totalTris, source.subMeshCount, 0);
+
+            WorkingMesh mesh = new WorkingMesh(Allocator.Persistent, source.vertexCount, totalTris, source.subMeshCount,
+                0);
             mesh.name = source.name;
             mesh.vertices = source.vertices;
             mesh.normals = source.normals;
@@ -996,7 +1021,7 @@ namespace Unity.HLODSystem
             parentQueue.Enqueue(-1);
             nameQueue.Enqueue("HLOD");
             depthQueue.Enqueue(0);
-            
+
 
             while (trevelQueue.Count > 0)
             {
@@ -1018,12 +1043,13 @@ namespace Unity.HLODSystem
                     nameQueue.Enqueue(name + "_" + (i + 1));
                     depthQueue.Enqueue(depth + 1);
                 }
-                
+
                 info.Heightmap = CreateSubHightmap(node.Bounds);
-                info.WorkingObjects.Add(CreateBakedTerrain(name, node.Bounds, info.Heightmap, depth, node.GetChildCount() == 0));
+                info.WorkingObjects.Add(CreateBakedTerrain(name, node.Bounds, info.Heightmap, depth,
+                    node.GetChildCount() == 0));
                 info.Distances.Add(depth);
                 results.Add(info);
-                
+
                 if (depth > maxDepth)
                     maxDepth = depth;
             }
@@ -1040,8 +1066,8 @@ namespace Unity.HLODSystem
 
             return results;
         }
-        
-        public IEnumerator CreateImpl()
+
+        public IEnumerator CreateImpl(Action callback)
         {
             try
             {
@@ -1068,7 +1094,8 @@ namespace Unity.HLODSystem
                     string materialPath = AssetDatabase.GUIDToAssetPath(m_hlod.MaterialGUID);
                     m_terrainMaterial = AssetDatabase.LoadAssetAtPath<Material>(materialPath);
                     if (m_terrainMaterial == null)
-                        m_terrainMaterial = new Material(Shader.Find("Lightweight Render Pipeline/Lit-Terrain-HLOD-High"));
+                        m_terrainMaterial =
+                            new Material(Shader.Find("Lightweight Render Pipeline/Lit-Terrain-HLOD-High"));
 
                     m_terrainMaterialInstanceId = m_terrainMaterial.GetInstanceID();
                     m_terrainMaterialName = m_terrainMaterial.name;
@@ -1076,7 +1103,8 @@ namespace Unity.HLODSystem
                     materialPath = AssetDatabase.GUIDToAssetPath(m_hlod.MaterialLowGUID);
                     m_terrainMaterialLow = AssetDatabase.LoadAssetAtPath<Material>(materialPath);
                     if (m_terrainMaterialLow == null)
-                        m_terrainMaterialLow = new Material(Shader.Find("Lightweight Render Pipeline/Lit-Terrain-HLOD-Low"));
+                        m_terrainMaterialLow =
+                            new Material(Shader.Find("Lightweight Render Pipeline/Lit-Terrain-HLOD-Low"));
 
                     m_terrainMaterialLowInstanceId = m_terrainMaterialLow.GetInstanceID();
                     m_terrainMaterialLowName = m_terrainMaterialLow.name;
@@ -1097,8 +1125,9 @@ namespace Unity.HLODSystem
 
                         QuadTreeSpaceSplitter splitter = new QuadTreeSpaceSplitter(null);
 
-                        List<SpaceNode> rootNodeList = splitter.CreateSpaceTree(m_hlod.GetBounds(), m_hlod.ChunkSize * 2.0f,
-                        m_hlod.transform, null, progress => { });
+                        List<SpaceNode> rootNodeList = splitter.CreateSpaceTree(m_hlod.GetBounds(),
+                            m_hlod.ChunkSize * 2.0f,
+                            m_hlod.transform, null, progress => { });
 
                         EditorUtility.DisplayProgressBar("Bake HLOD", "Create mesh", 0.0f);
                         foreach (var rootNode in rootNodeList)
@@ -1113,9 +1142,9 @@ namespace Unity.HLODSystem
                                     int curIndex = i;
                                     m_queue.EnqueueJob(() =>
                                     {
-                                        ISimplifier simplifier = (ISimplifier)Activator.CreateInstance(
+                                        ISimplifier simplifier = (ISimplifier) Activator.CreateInstance(
                                             m_hlod.SimplifierType,
-                                            new object[] { m_hlod.SimplifierOptions });
+                                            new object[] {m_hlod.SimplifierOptions});
                                         simplifier.SimplifyImmidiate(buildInfos[curIndex]);
                                     });
                                 }
@@ -1138,7 +1167,7 @@ namespace Unity.HLODSystem
                                             WorkingObject o = info.WorkingObjects[oi];
                                             int borderVertexCount = m_hlod.BorderVertexCount *
                                                                     Mathf.RoundToInt(Mathf.Pow(2.0f,
-                                                                        (float)info.Distances[oi]));
+                                                                        (float) info.Distances[oi]));
                                             using (WorkingMesh m = MakeBorder(o.Mesh, info.Heightmap,
                                                        borderVertexCount))
                                             {
@@ -1184,7 +1213,6 @@ namespace Unity.HLODSystem
                                             List<Material> materials = new List<Material>();
                                             for (int mi = 0; mi < wo.Materials.Count; ++mi)
                                             {
-
                                                 WorkingMaterial wm = wo.Materials[mi];
                                                 if (wm.NeedWrite() == false)
                                                 {
@@ -1225,8 +1253,8 @@ namespace Unity.HLODSystem
 
                                 //controller
                                 IStreamingBuilder builder =
-                                    (IStreamingBuilder)Activator.CreateInstance(m_hlod.StreamingType,
-                                        new object[] { m_hlod, m_hlod.StreamingOptions });
+                                    (IStreamingBuilder) Activator.CreateInstance(m_hlod.StreamingType,
+                                        new object[] {m_hlod, m_hlod.StreamingOptions});
 
                                 builder.Build(rootNode, buildInfos, m_hlod.gameObject, m_hlod.CullDistance,
                                     m_hlod.LODDistance, true, false,
@@ -1237,7 +1265,6 @@ namespace Unity.HLODSystem
                                     });
 
                                 Debug.Log("[TerrainHLOD] Build: " + sw.Elapsed.ToString("g"));
-
                             }
                         }
                     }
@@ -1250,9 +1277,8 @@ namespace Unity.HLODSystem
                 EditorUtility.ClearProgressBar();
                 GC.Collect();
             }
+
+            callback?.Invoke();
         }
-
-        
     }
-
 }

--- a/com.unity.hlod/Runtime/TerrainHLOD.cs
+++ b/com.unity.hlod/Runtime/TerrainHLOD.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -33,12 +32,10 @@ namespace Unity.HLODSystem
         [SerializeField] private string m_albedoPropertyName = "";
         [SerializeField] private string m_normalPropertyName = "";
         [SerializeField] private string m_maskPropertyName = "";
-        
-        [SerializeField]
-        private List<Object> m_generatedObjects = new List<Object>();
-        [SerializeField]
-        private List<GameObject> m_convertedPrefabObjects = new List<GameObject>();
-        
+
+        [SerializeField] private List<Object> m_generatedObjects = new List<Object>();
+        [SerializeField] private List<GameObject> m_convertedPrefabObjects = new List<GameObject>();
+
         public Type SimplifierType
         {
             set { m_SimplifierType = value; }
@@ -53,14 +50,16 @@ namespace Unity.HLODSystem
 
         public TerrainData TerrainData
         {
-            set { m_TerrainData = value;}
+            set { m_TerrainData = value; }
             get { return m_TerrainData; }
         }
+
         public bool DestroyTerrain
         {
             set { m_DestroyTerrain = value; }
             get { return m_DestroyTerrain; }
         }
+
         public float ChunkSize
         {
             get { return m_ChunkSize; }
@@ -84,15 +83,17 @@ namespace Unity.HLODSystem
             get { return m_CullDistance; }
             set { m_CullDistance = value; }
         }
-        
+
         public SerializableDynamicObject SimplifierOptions
         {
             get { return m_SimplifierOptions; }
+            set => m_SimplifierOptions = value;
         }
 
         public SerializableDynamicObject StreamingOptions
         {
-            get { return m_StreamingOptions; }
+            get => m_StreamingOptions;
+            set => m_SimplifierOptions = value;
         }
 
         public int TextureSize
@@ -142,16 +143,17 @@ namespace Unity.HLODSystem
             set { m_maskPropertyName = value; }
             get { return m_maskPropertyName; }
         }
-        
+
         public List<Object> GeneratedObjects
         {
             get { return m_generatedObjects; }
         }
+
         public List<GameObject> ConvertedPrefabObjects
         {
             get { return m_convertedPrefabObjects; }
         }
-        
+
         public void OnBeforeSerialize()
         {
             if (m_SimplifierType != null)
@@ -179,7 +181,6 @@ namespace Unity.HLODSystem
             {
                 m_StreamingType = Type.GetType(m_StreamingTypeStr);
             }
-
         }
 
         public void AddGeneratedResource(Object obj)
@@ -196,13 +197,12 @@ namespace Unity.HLODSystem
         {
             m_convertedPrefabObjects.Add(obj);
         }
-        
+
         public Bounds GetBounds()
         {
-            if ( m_TerrainData == null )
+            if (m_TerrainData == null)
                 return new Bounds();
             return new Bounds(m_TerrainData.size * 0.5f, m_TerrainData.size);
         }
-
     }
 }


### PR DESCRIPTION
### Purpose of this PR
NullReferenceException when no Normal map or Mask map provided in TerrainHLOD

---
### Release Notes
* Implemented new Create method in TerrainHLODCreator for Action callback when HLOD creation completed.
* Made public options for TerrainHLOD

This helped me automate creating via custom editor gui create HLODs for multiple terrains at once.

---
### Testing status
Tested this on my project in Unity 2023.3.18f1

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

#### No new features from ground up was created. Only few fixes and callback.
---

