### PR TITLE
Fix:Build error resolved.

### DIFF
--- a/com.unity.hlod/Runtime/HLODManager.cs
+++ b/com.unity.hlod/Runtime/HLODManager.cs
@@ -15,7 +15,7 @@ namespace Unity.HLODSystem
         #region Singleton
 
         private static HLODManager s_instance = null;
-        private bool IsSRP => GraphicsSettings.renderPipelineAsset != null || QualitySettings.renderPipeline != null;
+        private bool IsSRP => GraphicsSettings.defaultRenderPipeline != null || QualitySettings.renderPipeline != null;
 
         public static HLODManager Instance
         {
@@ -80,7 +80,7 @@ namespace Unity.HLODSystem
                     return;
             }
 #else
-            if (cam != HLODCameraRecognizer.RecognizedCamera)
+            if (cam != HLODCameraRecognizerManager.ActiveCamera)
                 return;
 #endif
 


### PR DESCRIPTION
### Purpose of this PR
When you make a build you get this error:

E:\Projects_GitHub\HLODSystem\com.unity.hlod\Runtime\HLODManager.cs(83,24): error CS0120: An object reference is required for the non-static field, method, or property 'HLODCameraRecognizer.RecognizedCamera'.

For the solution in HLODManager.cs script on line83 I have replaced:
```
if (cam != HLODCameraRecognizer.HLODCameraRecognizer)
    return;
```
with this
```
if (cam != HLODCameraRecognizerManager.ActiveCamera)
    return;
```

HLODCameraRecognizer in HLODCameraRecognizer script is not static, and the code were trying to access it with class name.
---
### Release Notes
If you find better way to do this job. Please do this and discard this PR. 

---
### Testing status
TBD

---
### Overall Product Risks
**Technical Risk**: None
**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
